### PR TITLE
Fix missing pip command

### DIFF
--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -15,8 +15,9 @@ class profile::base {
 
   include ::profile::common::concat
   include ::profile::common::accounts
-  include ::profile::common::cloudwatch
 
+  contain(::profile::common::cloudwatch, ::awscli)
+  Class['::profile::common::cloudwatch'] -> Class['::awscli']
 
   profile::register_profile { 'base': order => 1, }
 
@@ -25,7 +26,6 @@ class profile::base {
   }
 
   if $::ec2_metadata {
-    include ::awscli
     include profile::common::helper_scripts
   }
 


### PR DESCRIPTION
bug(missing_pip_command): fix ordering of puppet classes in profile::base

* awscli must be executed after profile::base::cloudwatch (to get puppet-python & pip)