### PR TITLE
DEVOPS-1631 : use main stack name in Cloudwatch custom namespace

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -30,7 +30,7 @@ packagecloud_repos:
 cloudwatchlogs::params::region: "%{::region}"
 profile::common::ssm::region: "%{::region}"
 
-cloudwatch::params::namespace: "talend-cloud/%{::puppet_role}"
+cloudwatch::params::namespace: "talend-cloud/%{::main_stack}/%{::puppet_role}"
 
 cloudwatchlog_files:
   "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/cfn-init.log":


### PR DESCRIPTION
feat(DEVOPS-1631): add the name of the CF main stack to CLoudwatch custom namespace