### PR TITLE
fix swap location for MongoDB

### DIFF
--- a/site/profile/manifests/mongodb.pp
+++ b/site/profile/manifests/mongodb.pp
@@ -42,12 +42,6 @@ class profile::mongodb (
     $create_admin = true
   }
 
-  swap_file::files { 'mongo_swap':
-    ensure       => $swap_ensure,
-    swapfile     => '/mnt/mongo.swap',
-    swapfilesize => $::memorysize,
-  }
-
   # explicitly only support replica sets of size 3
   if size($_mongo_nodes) == 3 {
     if empty($::mongodb_replset_name) {
@@ -223,6 +217,13 @@ class profile::mongodb (
       owner                   => 'mongod',
       group                   => 'mongod',
       fixup_ownership_require => Package['mongodb_server']
+    }
+
+    swap_file::files { 'mongo_swap':
+      ensure       => $swap_ensure,
+      swapfile     => "${dbpath}/mongo.swap",
+      swapfilesize => $::memorysize,
+      require      => Class['::profile::common::mount_device::fixup_ownership']
     }
   }
 

--- a/spec/acceptance/shared/mongodb.rb
+++ b/spec/acceptance/shared/mongodb.rb
@@ -22,11 +22,11 @@ shared_examples 'profile::mongodb' do
   end
 
   describe 'Verifying swap' do
-    describe file('/mnt/mongo.swap') do
+    describe file('/var/lib/mongo/mongo.swap') do
       it { should be_file }
     end
     describe command('/sbin/swapon') do
-      its(:stdout) { should include '/mnt/mongo.swap file' }
+      its(:stdout) { should include '/var/lib/mongo/mongo.swap file' }
     end
   end
 


### PR DESCRIPTION
With strong HW, there is not enough disk space on the system for the swap.
So, for mongo, we put it in the data volume once the rights for mongo user has been modified (swap stays for root only).

Tested locally:
``` bash
(DEVOPS-3361-fix-swap-place) λ ./scripts/local_dev_tests.sh -t role-mongodb-centos-73
...
Finished in 8.69 seconds (files took 0.29349 seconds to load)
131 examples, 0 failures
...
```