### PR TITLE
Devops 3626 mongodb profiles

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -150,25 +150,6 @@ suites:
     verifier:
       patterns:
         - 'spec/acceptance/mongodb_versioned_spec.rb'
-  - name: role-mongodb_default_profile
-    driver:
-      vagrantfiles:
-        - vagrant/second_disk.rb
-    provisioner:
-      custom_pre_install_command: |
-        sudo /usr/sbin/mkfs.xfs /dev/sdb
-        sudo /usr/bin/mount /dev/sdb /mnt
-        sudo /usr/bin/touch /mnt/mongod.lock
-        sudo /usr/bin/chown root:root /mnt/mongod.lock
-        sudo /usr/bin/umount /mnt
-      custom_facts:
-        puppet_role: mongodb
-        cfn_resource_name: InstanceA
-        storage_device: /dev/sdb
-        mongo_replset_auth_enable: true
-    verifier:
-      patterns:
-        - 'spec/acceptance/mongodb_default_profile_spec.rb'
   - name: role-mongodb_tds_profile
     driver:
       vagrantfiles:
@@ -185,6 +166,7 @@ suites:
         cfn_resource_name: InstanceA
         storage_device: /dev/sdb
         mongo_replset_auth_enable: true
+        mongodb_yaml_profile_name: mongodb_tds_profile
     verifier:
       patterns:
         - 'spec/acceptance/mongodb_tds_profile_spec.rb'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -150,6 +150,44 @@ suites:
     verifier:
       patterns:
         - 'spec/acceptance/mongodb_versioned_spec.rb'
+  - name: role-mongodb_default_profile
+    driver:
+      vagrantfiles:
+        - vagrant/second_disk.rb
+    provisioner:
+      custom_pre_install_command: |
+        sudo /usr/sbin/mkfs.xfs /dev/sdb
+        sudo /usr/bin/mount /dev/sdb /mnt
+        sudo /usr/bin/touch /mnt/mongod.lock
+        sudo /usr/bin/chown root:root /mnt/mongod.lock
+        sudo /usr/bin/umount /mnt
+      custom_facts:
+        puppet_role: mongodb
+        cfn_resource_name: InstanceA
+        storage_device: /dev/sdb
+        mongo_replset_auth_enable: true
+    verifier:
+      patterns:
+        - 'spec/acceptance/mongodb_default_profile_spec.rb'
+  - name: role-mongodb_tds_profile
+    driver:
+      vagrantfiles:
+        - vagrant/second_disk.rb
+    provisioner:
+      custom_pre_install_command: |
+        sudo /usr/sbin/mkfs.xfs /dev/sdb
+        sudo /usr/bin/mount /dev/sdb /mnt
+        sudo /usr/bin/touch /mnt/mongod.lock
+        sudo /usr/bin/chown root:root /mnt/mongod.lock
+        sudo /usr/bin/umount /mnt
+      custom_facts:
+        puppet_role: mongodb
+        cfn_resource_name: InstanceA
+        storage_device: /dev/sdb
+        mongo_replset_auth_enable: true
+    verifier:
+      patterns:
+        - 'spec/acceptance/mongodb_tds_profile_spec.rb'
   - name: role-test
     provisioner:
       custom_facts:

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -88,7 +88,7 @@ GIT
 GIT
   remote: https://github.com/Talend/puppet-mongodb.git
   ref: 0.18.x
-  sha: b2e9932b5ba90b8e0404885da35c94f1977210ad
+  sha: e59ad3a9c30fc68ea903c445c1a37ea1ce6e74ef
   specs:
     puppetlabs-mongodb (0.18.0)
       puppetlabs-apt (< 3.0.0, >= 2.1.0)

--- a/hieradata/environment/vagrant.yaml
+++ b/hieradata/environment/vagrant.yaml
@@ -7,6 +7,11 @@ tic::services::rt_flow_instance_profile: 'test-instance_profile'
 tic::services::rt_flow_t_release:         'my-release'
 tic::services::rt_flow_t_branch:          'my-branch'
 
+mongodb_tds_profile_overrode:
+  users:
+    provisioning:
+      password: 'isnotmasterpassword'
+
 profile::common::hosts::entries:
   mongo:
     entries: '[ "10.0.2.12", "10.0.2.23" ]'

--- a/hieradata/puppet_role/mongodb.yaml
+++ b/hieradata/puppet_role/mongodb.yaml
@@ -126,10 +126,14 @@ mongodb_tds_profile:
   replset_name: 'tds'
   storage_engine: 'wiredTiger'
   users:
-    tds:
-      db_address: 'tds'
-      username: 'tds'
+    provisioning:
+      db_address: 'admin'
+      username: 'provisioning'
       password: '%{::master_password}'
       roles:
-        - role: 'dbOwner'
-          db: 'tds'
+        - role: 'userAdminAnyDatabase'
+          db: 'admin'
+        - role: 'dbAdminAnyDatabase'
+          db: 'admin'
+        - role: 'readWriteAnyDatabase'
+          db: 'admin'

--- a/hieradata/puppet_role/mongodb.yaml
+++ b/hieradata/puppet_role/mongodb.yaml
@@ -7,6 +7,7 @@ mongodb::server::verbose: true
 profile::mongodb::replset_auth_enable: '%{::mongo_replset_auth_enable}'
 profile::mongodb::mongodb_nodes: "%{::mongodb_nodes}"
 profile::mongodb::storage_device: "%{::storage_device}"
+profile::mongodb::mongodb_yaml_profile_name: "%{::mongodb_yaml_profile_name}"
 
 profile::mongodb::admin_user: "sreadmin"
 profile::mongodb::admin_password: "%{::master_password}"
@@ -38,25 +39,6 @@ profile::mongodb::roles:
     roles: []
 
 profile::mongodb::users:
-  admin:
-    db_address: 'ipaas'
-    username: 'admin'
-    password: "%{::master_password}"
-    roles:
-      - role: 'userAdminAnyDatabase'
-        db: 'admin'
-      - role: 'dbAdminAnyDatabase'
-        db: 'admin'
-      - role: 'readWriteAnyDatabase'
-        db: 'admin'
-      - role: 'dbOwner'
-        db: 'ipaas'
-  tpsvc_config:
-    db_address: 'configuration'
-    password: "%{::master_password}"
-    roles:
-      - role: 'dbOwner'
-        db: 'configuration'
   backup:
     db_address: 'admin'
     username: 'backup'
@@ -78,20 +60,6 @@ profile::mongodb::users:
     roles:
       - role: 'clusterMonitor'
         db: 'admin'
-  dq:
-    db_address: 'dqdict'
-    username: 'dqdict-user'
-    password: '%{::master_password}'
-    roles:
-      - role: 'dbOwner'
-        db: 'dqdict'
-  tds:
-    db_address: 'tds'
-    username: 'tds'
-    password: '%{::master_password}'
-    roles:
-      - role: 'dbOwner'
-        db: 'tds'
 
 logrotate::ensure: 'present'
 logrotate::hieramerge: true
@@ -120,3 +88,48 @@ cloudwatchlog_files:
   "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/mongodb/mongod.log":
      path: '/var/log/mongodb/mongod.log'
      datetime_format: '%b %d %H:%M:%S'
+
+# IPAAS MongoDB replicaset profile
+mongodb_default_profile:
+  replset_name: 'tipaas'
+  storage_engine: 'mmapv1'
+  users:
+    admin:
+      db_address: 'ipaas'
+      username: 'admin'
+      password: "%{::master_password}"
+      roles:
+        - role: 'userAdminAnyDatabase'
+          db: 'admin'
+        - role: 'dbAdminAnyDatabase'
+          db: 'admin'
+        - role: 'readWriteAnyDatabase'
+          db: 'admin'
+        - role: 'dbOwner'
+          db: 'ipaas'
+    tpsvc_config:
+      db_address: 'configuration'
+      password: "%{::master_password}"
+      roles:
+        - role: 'dbOwner'
+          db: 'configuration'
+    dq:
+      db_address: 'dqdict'
+      username: 'dqdict-user'
+      password: '%{::master_password}'
+      roles:
+        - role: 'dbOwner'
+          db: 'dqdict'
+
+# TDS MongoDB replicaset profile
+mongodb_tds_profile:
+  replset_name: 'tds'
+  storage_engine: 'wiredTiger'
+  users:
+    tds:
+      db_address: 'tds'
+      username: 'tds'
+      password: '%{::master_password}'
+      roles:
+        - role: 'dbOwner'
+          db: 'tds'

--- a/site/profile/manifests/mongodb.pp
+++ b/site/profile/manifests/mongodb.pp
@@ -14,7 +14,8 @@ class profile::mongodb (
   $admin_password      = undef,
   $users               = {},
   $roles               = {},
-  $swap_ensure         = 'present'
+  $swap_ensure         = 'present',
+  $mongodb_yaml_profile_name = undef,
 ) {
 
   require ::profile::common::packages
@@ -36,34 +37,47 @@ class profile::mongodb (
 
   $mongo_auth_asked = str2bool($replset_auth_enable)
 
+  if empty($mongodb_yaml_profile_name){
+    $mongodb_yaml_profile = {}
+  } else {
+    $mongodb_yaml_profile = hiera($mongodb_yaml_profile_name, {})
+  }
+
+  if has_key($mongodb_yaml_profile, 'replset_name') {
+    $replset_name = $mongodb_yaml_profile['replset_name']
+  } else {
+    $replset_name = 'tipaas'
+  }
+
+  if has_key($mongodb_yaml_profile, 'storage_engine') {
+    $storage_engine = $mongodb_yaml_profile['storage_engine']
+  } else {
+    $storage_engine = 'mmapv1'
+  }
+
+  if has_key($mongodb_yaml_profile, 'users') {
+    $_users = deep_merge($users, $mongodb_yaml_profile['users'])
+  } else {
+    $_users = $users
+  }
+
   if empty($admin_user) or empty($admin_password){
     $create_admin = false
   } else {
     $create_admin = true
   }
 
-  # explicitly only support replica sets of size 3
-  if size($_mongo_nodes) == 3 {
-    if empty($::mongodb_replset_name) {
-      $replset_name = 'tipaas'
-    } else {
-      $replset_name = $::mongodb_replset_name
+  $replset_config = {
+    "${replset_name}" => {
+      ensure  => 'present',
+      members => $_mongo_nodes
     }
+  }
 
-    $replset_config = {
-      "${replset_name}" => {
-        ensure  => 'present',
-        members => $_mongo_nodes
-      }
-    }
-
-    if $mongo_auth_asked {
-      $keyfile = '/var/lib/mongo/shared_key'
-    } else {
-      $keyfile = undef
-    }
+  if $mongo_auth_asked {
+    $keyfile = '/var/lib/mongo/shared_key'
   } else {
-    $replset_name = undef
+    $keyfile = undef
   }
 
   file { 'mongod disable-transparent-hugepages':
@@ -192,7 +206,8 @@ class profile::mongodb (
     syslog         => true,
     create_admin   => $create_admin,
     admin_username => $admin_user,
-    admin_password => $admin_password
+    admin_password => $admin_password,
+    storage_engine => $storage_engine,
   } ->
   profile::mongodb::wait_for_mongod { 'before auth':
   } ->
@@ -205,7 +220,7 @@ class profile::mongodb (
     roles => $roles,
   } ->
   class { '::profile::mongodb::users':
-    users => $users,
+    users => $_users,
   } ->
   class { '::profile::mongodb::rs_config':
     replset_name => $replset_name,

--- a/site/profile/manifests/mongodb/collection.pp
+++ b/site/profile/manifests/mongodb/collection.pp
@@ -21,28 +21,28 @@ define profile::mongodb::collection (
     $index_options_str = regsubst(to_json_ex($index_options), '\"', '\\"', 'G')
 
     if $::profile::mongodb::mongo_auth_already_enabled or $::profile::mongodb::mongo_auth_asked {
-      $create_coll_cmd = "mongo --quiet admin -u ${::profile::mongodb::admin_user} \
+      $create_coll_cmd = "mongo --norc --quiet admin -u ${::profile::mongodb::admin_user} \
         -p ${::profile::mongodb::admin_password} \
         --eval \"db=db.getSiblingDB('${db_address}'); \
         db.createCollection('${collection_name}', ${options_str});\""
 
-      $create_index_cmd = "mongo --quiet admin -u ${::profile::mongodb::admin_user} \
+      $create_index_cmd = "mongo --norc --quiet admin -u ${::profile::mongodb::admin_user} \
         -p ${::profile::mongodb::admin_password} \
         --eval \"db=db.getSiblingDB('${db_address}'); \
         db.${collection_name}.createIndex(${index_keys_str}, ${index_options_str});\""
 
-      $verify_coll_cmd = "mongo --quiet admin -u ${::profile::mongodb::admin_user} \
+      $verify_coll_cmd = "mongo --norc --quiet admin -u ${::profile::mongodb::admin_user} \
         -p ${::profile::mongodb::admin_password} \
         --eval \"db=db.getSiblingDB('${db_address}'); \
         printjson(db.getCollectionNames());\" | grep -q '\"${collection_name}\"'"
     } else {
-      $create_coll_cmd = "mongo --quiet ${db_address} \
+      $create_coll_cmd = "mongo --norc --quiet ${db_address} \
         --eval \"db.createCollection('${collection_name}', ${options_str});\""
 
-      $create_index_cmd = "mongo --quiet ${db_address} \
+      $create_index_cmd = "mongo --norc --quiet ${db_address} \
         --eval \"db.${collection_name}.createIndex(${index_keys_str}, ${index_options_str});\""
 
-      $verify_coll_cmd = "mongo --quiet ${db_address} \
+      $verify_coll_cmd = "mongo --norc --quiet ${db_address} \
         --eval \"printjson(db.getCollectionNames());\" | grep -q '\"${collection_name}\"'"
     }
 
@@ -50,8 +50,7 @@ define profile::mongodb::collection (
       path    => '/bin:/usr/bin',
       command => $create_coll_cmd,
       unless  => $verify_coll_cmd,
-      onlyif  => "grep -q true ${::profile::mongodb::is_primary::primary_flag_file}",
-      require => File[$::profile::mongodb::is_primary::primary_flag_file]
+      onlyif  => "grep -q true ${::profile::mongodb::is_primary::primary_flag_file}"
     }
 
     if str2bool($create_index) {

--- a/site/profile/manifests/mongodb/rs_config.pp
+++ b/site/profile/manifests/mongodb/rs_config.pp
@@ -13,13 +13,10 @@ class profile::mongodb::rs_config (
       rs.reconfig(cfg);"
 
     if $::profile::mongodb::mongo_auth_already_enabled or $::profile::mongodb::mongo_auth_asked {
-      $reconfig_mongo_cmd = "mongo --quiet admin -u ${::profile::mongodb::admin_user} \
+      $reconfig_mongo_cmd = "mongo --norc --quiet admin -u ${::profile::mongodb::admin_user} \
         -p ${::profile::mongodb::admin_password} --eval '${mongo_cmd}'"
-      $reconfig_verify_cmd = "mongo --quiet admin -u ${::profile::mongodb::admin_user} \
-        -p ${::profile::mongodb::admin_password} --eval 'printjson(rs.status().set);' | grep -qv '^\"${_replset_settings}\"$'"
     } else {
-      $reconfig_mongo_cmd = "mongo --quiet admin --eval '${mongo_cmd}'"
-      $reconfig_verify_cmd = "mongo --quiet admin --eval 'printjson(rs.status().set);' | grep -qv '^\"${_replset_settings}\"$'"
+      $reconfig_mongo_cmd = "mongo --norc --quiet admin --eval '${mongo_cmd}'"
     }
 
     exec { 'Configure ReplicationSet settings':

--- a/site/profile/manifests/mongodb/user.pp
+++ b/site/profile/manifests/mongodb/user.pp
@@ -16,7 +16,7 @@ define profile::mongodb::user (
     $roles_str = regsubst(to_json_ex($roles), '\"', '\\"', 'G')
 
     if $::profile::mongodb::mongo_auth_already_enabled or $::profile::mongodb::mongo_auth_asked {
-      $create_user_cmd = "mongo --quiet admin -u ${::profile::mongodb::admin_user} \
+      $create_user_cmd = "mongo --norc --quiet admin -u ${::profile::mongodb::admin_user} \
         -p ${::profile::mongodb::admin_password} \
         --eval \"db=db.getSiblingDB('${db_address}'); \
           db.createUser({ \
@@ -24,18 +24,18 @@ define profile::mongodb::user (
             pwd: '${password}', \
             roles: ${roles_str} \
           });\""
-      $verify_cmd = "mongo --quiet admin -u ${::profile::mongodb::admin_user} \
+      $verify_cmd = "mongo --norc --quiet admin -u ${::profile::mongodb::admin_user} \
         -p ${::profile::mongodb::admin_password} \
         --eval \"db=db.getSiblingDB('${db_address}'); \
         printjson(db.getUser('${username}'));\" \
         | tr -d \"\t\n \" | grep -qv \"^null$\""
     } else {
-      $create_user_cmd = "mongo --quiet ${db_address} --eval \"db.createUser({ \
+      $create_user_cmd = "mongo --norc --quiet ${db_address} --eval \"db.createUser({ \
         user: '${username}', \
         pwd: '${password}', \
         roles: ${roles_str} \
       });\""
-      $verify_cmd = "mongo --quiet ${db_address} \
+      $verify_cmd = "mongo --norc --quiet ${db_address} \
         --eval \"printjson(db.getUser('${username}'));\" \
         | tr -d \"\t\n \" | grep -qv \"^null$\""
     }
@@ -44,8 +44,7 @@ define profile::mongodb::user (
       path    => '/bin:/usr/bin',
       command => $create_user_cmd,
       unless  => $verify_cmd,
-      onlyif  => "grep -q true ${::profile::mongodb::is_primary::primary_flag_file}",
-      require => File[$::profile::mongodb::is_primary::primary_flag_file]
+      onlyif  => "grep -q true ${::profile::mongodb::is_primary::primary_flag_file}"
     }
   }
 }

--- a/spec/acceptance/mongodb_default_profile_spec.rb
+++ b/spec/acceptance/mongodb_default_profile_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'role::mongodb' do
+  it_behaves_like 'profile::base'
+  it_behaves_like 'profile::rsyslog'
+  it_behaves_like 'profile::mongodb'
+  it_behaves_like 'profile::mongodb_default_profile'
+  it_behaves_like 'role::defined', 'mongodb'
+end

--- a/spec/acceptance/mongodb_default_profile_spec.rb
+++ b/spec/acceptance/mongodb_default_profile_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe 'role::mongodb' do
-  it_behaves_like 'profile::base'
-  it_behaves_like 'profile::rsyslog'
-  it_behaves_like 'profile::mongodb'
-  it_behaves_like 'profile::mongodb_default_profile'
-  it_behaves_like 'role::defined', 'mongodb'
-end

--- a/spec/acceptance/mongodb_spec.rb
+++ b/spec/acceptance/mongodb_spec.rb
@@ -4,5 +4,6 @@ describe 'role::mongodb' do
   it_behaves_like 'profile::base'
   it_behaves_like 'profile::rsyslog'
   it_behaves_like 'profile::mongodb'
+  it_behaves_like 'profile::mongodb_default_profile'
   it_behaves_like 'role::defined', 'mongodb'
 end

--- a/spec/acceptance/mongodb_tds_profile_spec.rb
+++ b/spec/acceptance/mongodb_tds_profile_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'role::mongodb' do
+  it_behaves_like 'profile::base'
+  it_behaves_like 'profile::rsyslog'
+  it_behaves_like 'profile::mongodb'
+  it_behaves_like 'profile::mongodb_tds_profile'
+  it_behaves_like 'role::defined', 'mongodb'
+end

--- a/spec/acceptance/mongodb_versioned_spec.rb
+++ b/spec/acceptance/mongodb_versioned_spec.rb
@@ -4,6 +4,7 @@ describe 'role::mongodb' do
   it_behaves_like 'profile::base'
   it_behaves_like 'profile::rsyslog'
   it_behaves_like 'profile::mongodb'
+  it_behaves_like 'profile::mongodb_default_profile'
   it_behaves_like 'profile::mongodb_versioned'
   it_behaves_like 'role::defined', 'mongodb'
 end

--- a/spec/acceptance/shared/mongodb.rb
+++ b/spec/acceptance/shared/mongodb.rb
@@ -162,17 +162,6 @@ shared_examples 'profile::mongodb' do
     its(:stdout) { should include '{"role":"restore","db":"admin"}' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u admin -p mypassword ipaas --eval "printjson(db.getUser(\'admin\'));" | /usr/bin/tr -d "\t\n "') do
-    its(:stdout) { should include '{"role":"userAdminAnyDatabase","db":"admin"}' }
-    its(:stdout) { should include '{"role":"dbAdminAnyDatabase","db":"admin"}' }
-    its(:stdout) { should include '{"role":"readWriteAnyDatabase","db":"admin"}' }
-    its(:stdout) { should include '{"role":"dbOwner","db":"ipaas"}' }
-  end
-
-  describe command('/usr/bin/mongo --quiet -u tpsvc_config -p mypassword configuration --eval "printjson(db.getUser(\'tpsvc_config\'));" | /usr/bin/tr -d "\t\n "') do
-    its(:stdout) { should include '{"role":"dbOwner","db":"configuration"}' }
-  end
-
   describe command('/usr/bin/mongo --quiet -u backup -p mypassword admin --eval "printjson(db.getUser(\'backup\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"backupRole","db":"admin"}' }
   end
@@ -185,13 +174,6 @@ shared_examples 'profile::mongodb' do
     its(:stdout) { should include '{"role":"clusterMonitor","db":"admin"}' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u dqdict-user -p mypassword dqdict --eval "printjson(db.getUser(\'dqdict-user\'));" | /usr/bin/tr -d "\t\n "') do
-    its(:stdout) { should include '{"role":"dbOwner","db":"dqdict"}' }
-  end
-
-  describe command('/usr/bin/mongo --quiet -u tds -p mypassword tds --eval "printjson(db.getUser(\'tds\'));" | /usr/bin/tr -d "\t\n "') do
-    its(:stdout) { should include '{"role":"dbOwner","db":"tds"}' }
-  end
 
   describe 'Logrotate configuration' do
     describe file('/etc/logrotate.d/hourly/mongodb_log') do

--- a/spec/acceptance/shared/mongodb.rb
+++ b/spec/acceptance/shared/mongodb.rb
@@ -105,10 +105,10 @@ shared_examples 'profile::mongodb' do
       it { should be_file }
       its(:content) { should include 'security.authorization: enabled' }
     end
-    describe command('/usr/bin/mongo --quiet -u sreadmin -p mypassword admin --eval "db.help();"') do
+    describe command('/usr/bin/mongo --norc --quiet -u sreadmin -p mypassword admin --eval "db.help();"') do
       its(:exit_status) { should eq 0 }
     end
-    describe command('/usr/bin/mongo --quiet -u sreadmin -p mybadpassword admin --eval "db.help();"') do
+    describe command('/usr/bin/mongo --norc --quiet -u sreadmin -p mybadpassword admin --eval "db.help();"') do
       its(:exit_status) { should eq 1 }
     end
   end
@@ -146,7 +146,7 @@ shared_examples 'profile::mongodb' do
     its(:stdout) { should include 'xfs' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u sreadmin -p mypassword admin --eval "printjson(db.getUser(\'sreadmin\'));" | /usr/bin/tr -d "\t\n "') do
+  describe command('/usr/bin/mongo --norc --quiet -u sreadmin -p mypassword admin --eval "printjson(db.getUser(\'sreadmin\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"userAdmin","db":"admin"}' }
     its(:stdout) { should include '{"role":"readWrite","db":"admin"}' }
     its(:stdout) { should include '{"role":"dbAdmin","db":"admin"}' }
@@ -162,15 +162,15 @@ shared_examples 'profile::mongodb' do
     its(:stdout) { should include '{"role":"restore","db":"admin"}' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u backup -p mypassword admin --eval "printjson(db.getUser(\'backup\'));" | /usr/bin/tr -d "\t\n "') do
+  describe command('/usr/bin/mongo --norc --quiet -u backup -p mypassword admin --eval "printjson(db.getUser(\'backup\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"backupRole","db":"admin"}' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u monitor -p mypassword admin --eval "printjson(db.getUser(\'monitor\'));" | /usr/bin/tr -d "\t\n "') do
+  describe command('/usr/bin/mongo --norc --quiet -u monitor -p mypassword admin --eval "printjson(db.getUser(\'monitor\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"clusterMonitor","db":"admin"}' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u datadog -p mypassword admin --eval "printjson(db.getUser(\'datadog\'));" | /usr/bin/tr -d "\t\n "') do
+  describe command('/usr/bin/mongo --norc --quiet -u datadog -p mypassword admin --eval "printjson(db.getUser(\'datadog\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"clusterMonitor","db":"admin"}' }
   end
 

--- a/spec/acceptance/shared/mongodb_default_profile.rb
+++ b/spec/acceptance/shared/mongodb_default_profile.rb
@@ -1,16 +1,16 @@
 shared_examples 'profile::mongodb_default_profile' do
-  describe command('/usr/bin/mongo --quiet -u admin -p mypassword ipaas --eval "printjson(db.getUser(\'admin\'));" | /usr/bin/tr -d "\t\n "') do
+  describe command('/usr/bin/mongo --norc --quiet -u admin -p mypassword ipaas --eval "printjson(db.getUser(\'admin\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"userAdminAnyDatabase","db":"admin"}' }
     its(:stdout) { should include '{"role":"dbAdminAnyDatabase","db":"admin"}' }
     its(:stdout) { should include '{"role":"readWriteAnyDatabase","db":"admin"}' }
     its(:stdout) { should include '{"role":"dbOwner","db":"ipaas"}' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u tpsvc_config -p mypassword configuration --eval "printjson(db.getUser(\'tpsvc_config\'));" | /usr/bin/tr -d "\t\n "') do
+  describe command('/usr/bin/mongo --norc --quiet -u tpsvc_config -p mypassword configuration --eval "printjson(db.getUser(\'tpsvc_config\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"dbOwner","db":"configuration"}' }
   end
 
-  describe command('/usr/bin/mongo --quiet -u dqdict-user -p mypassword dqdict --eval "printjson(db.getUser(\'dqdict-user\'));" | /usr/bin/tr -d "\t\n "') do
+  describe command('/usr/bin/mongo --norc --quiet -u dqdict-user -p mypassword dqdict --eval "printjson(db.getUser(\'dqdict-user\'));" | /usr/bin/tr -d "\t\n "') do
     its(:stdout) { should include '{"role":"dbOwner","db":"dqdict"}' }
   end
 end

--- a/spec/acceptance/shared/mongodb_default_profile.rb
+++ b/spec/acceptance/shared/mongodb_default_profile.rb
@@ -1,0 +1,16 @@
+shared_examples 'profile::mongodb_default_profile' do
+  describe command('/usr/bin/mongo --quiet -u admin -p mypassword ipaas --eval "printjson(db.getUser(\'admin\'));" | /usr/bin/tr -d "\t\n "') do
+    its(:stdout) { should include '{"role":"userAdminAnyDatabase","db":"admin"}' }
+    its(:stdout) { should include '{"role":"dbAdminAnyDatabase","db":"admin"}' }
+    its(:stdout) { should include '{"role":"readWriteAnyDatabase","db":"admin"}' }
+    its(:stdout) { should include '{"role":"dbOwner","db":"ipaas"}' }
+  end
+
+  describe command('/usr/bin/mongo --quiet -u tpsvc_config -p mypassword configuration --eval "printjson(db.getUser(\'tpsvc_config\'));" | /usr/bin/tr -d "\t\n "') do
+    its(:stdout) { should include '{"role":"dbOwner","db":"configuration"}' }
+  end
+
+  describe command('/usr/bin/mongo --quiet -u dqdict-user -p mypassword dqdict --eval "printjson(db.getUser(\'dqdict-user\'));" | /usr/bin/tr -d "\t\n "') do
+    its(:stdout) { should include '{"role":"dbOwner","db":"dqdict"}' }
+  end
+end

--- a/spec/acceptance/shared/mongodb_tds_profile.rb
+++ b/spec/acceptance/shared/mongodb_tds_profile.rb
@@ -1,0 +1,5 @@
+shared_examples 'profile::mongodb_tds_profile' do
+  describe command('/usr/bin/mongo --quiet -u tds -p mypassword tds --eval "printjson(db.getUser(\'tds\'));" | /usr/bin/tr -d "\t\n "') do
+    its(:stdout) { should include '{"role":"dbOwner","db":"tds"}' }
+  end
+end

--- a/spec/acceptance/shared/mongodb_tds_profile.rb
+++ b/spec/acceptance/shared/mongodb_tds_profile.rb
@@ -1,5 +1,15 @@
 shared_examples 'profile::mongodb_tds_profile' do
-  describe command('/usr/bin/mongo --quiet -u tds -p mypassword tds --eval "printjson(db.getUser(\'tds\'));" | /usr/bin/tr -d "\t\n "') do
-    its(:stdout) { should include '{"role":"dbOwner","db":"tds"}' }
+  describe 'Verifying password overiding' do
+    describe command('/usr/bin/mongo --norc --quiet -u provisioning -p mypassword admin --eval "db.help();"') do
+      its(:exit_status) { should eq 1 }
+    end
+  end
+
+  describe 'Verifying provisioning rights' do
+    describe command('/usr/bin/mongo --norc --quiet -u provisioning -p isnotmasterpassword admin --eval "printjson(db.getUser(\'provisioning\'));" | /usr/bin/tr -d "\t\n "') do
+      its(:stdout) { should include '{"role":"userAdminAnyDatabase","db":"admin"}' }
+      its(:stdout) { should include '{"role":"dbAdminAnyDatabase","db":"admin"}' }
+      its(:stdout) { should include '{"role":"readWriteAnyDatabase","db":"admin"}' }
+    end
   end
 end


### PR DESCRIPTION
Common work with @jmlrt to add profiling for MongoDB and being able to create a new replicaset with MongoDB 3.4.

Tested on talend-cloud-integration-tds-mongodb

Local tests:
``` bash
./scripts/local_dev_tests.sh -t role-mongodb-tds-profile-centos-73
...
Finished in 11.61 seconds (files took 0.31261 seconds to load)
131 examples, 0 failures

       Finished verifying <role-mongodb-tds-profile-centos-73> (0m12.31s).
-----> Destroying <role-mongodb-tds-profile-centos-73>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-mongodb-tds-profile-centos-73> destroyed.
       Finished destroying <role-mongodb-tds-profile-centos-73> (0m3.31s).
       Finished testing <role-mongodb-tds-profile-centos-73> (7m35.24s).
-----> Kitchen is finished. (7m35.44s)
```

``` bash
./scripts/local_dev_tests.sh -t role-mongodb-centos-73
...
Finished in 12.04 seconds (files took 0.3358 seconds to load)
133 examples, 0 failures

       Finished verifying <role-mongodb-centos-73> (0m12.78s).
-----> Destroying <role-mongodb-centos-73>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-mongodb-centos-73> destroyed.
       Finished destroying <role-mongodb-centos-73> (0m3.34s).
       Finished testing <role-mongodb-centos-73> (7m44.07s).
-----> Kitchen is finished. (7m44.25s)
```