### PR TITLE
Fix topic config alter command for more than one options

### DIFF
--- a/site/profile/manifests/kafka/broker_topic.pp
+++ b/site/profile/manifests/kafka/broker_topic.pp
@@ -28,7 +28,7 @@ define profile::kafka::broker_topic(
 
   if $ensure == 'present' {
     $topic_create_options  = inline_template('<% unless @topic_options.empty? %><% @topic_options.each do |key, value| %> --config <%= key %>=<%= value %><% end %><% end %>')
-    $topic_config_options  = inline_template('<% unless @topic_options.empty? %><% @topic_options.each do |key, value| %> --add-config <%= key %>=<%= value %><% end %><% end %>')
+    $topic_config_options  = inline_template('<% unless @topic_options.empty? %>--add-config "<% @topic_options.each do |key, value| %> <%= key %>=<%= value %>,<% end %>"<% end %>')
 
     unless empty($topic_options){
       exec { "configure topic ${name}":


### PR DESCRIPTION
I found that if a kafka topic already exists and then we want to add more than one topic level config, pnow can succeed but the output is empty when checking the topic config:
/opt/kafka/bin/kafka-configs.sh --zookeeper 10.72.4.17:2181/talend-cloud-integration-infra-kafka-apps --entity-type topics --entity-name dqDictionary --describe

So I dig out that our current code can work on config "alter" for one config but not for more.
When there are more than one options, our current command is:
--alter --add-config key=value --add-config key=value 
According to /opt/kafka/bin/kafka-configs.sh --help, it should be:
--alter  --add-config 'key=value,key=value'

/opt/kafka/bin/kafka-configs.sh --help
Option              Description                            
------              -----------                            
--add-config        Key Value pairs of configs to add.     
                      Square brackets can be used to group 
                      values which contain commas: 'k1=v1, 
                      k2=[v1,v2,v2],k3=v3'. The following  
                      is a list of valid configurations:   
                      For entity_type 'topics':            
                    	cleanup.policy                        
                    	compression.type    

It can not be detected by acceptance test because the topic is always new and the topic config is added when creating the topic which works well.

I have tested the command in integration cloud, after changing it, the topic config can show up using /opt/kafka/bin/kafka-configs.sh --zookeeper 10.72.4.17:2181/talend-cloud-integration-infra-kafka-apps --entity-type topics --entity-name dqDictionary --describe

