### PR TITLE
DEVOPS-3922: Introduced two new standard packages

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -28,6 +28,10 @@ common_packages:
   'awscli':
     ensure: 'installed'
     provider: 'pip'
+  'lnav':
+    ensure: 'installed'
+  'screen':
+    ensure: 'installed'
 
 packagecloud_repos:
   'talend/other':


### PR DESCRIPTION
@mmeyer-talend 
As far as I understand, it is not necessary to adapt any tests, since the tests should find and test the new packages automatically:

In https://github.com/Talend/talend-cloud-installer/blob/ab6b7519b8b7e86a2922b6a9b8d275e4fb2263ac/spec/acceptance/shared/common/packages.rb#L1

the test creates an array and fills it with the content of _'profile::common::packages'_ , iterates over it and executes the following test for each item:
https://github.com/Talend/talend-cloud-installer/blob/ab6b7519b8b7e86a2922b6a9b8d275e4fb2263ac/spec/acceptance/shared/common/packages.rb#L3-L5

In the class 'profile::common::packages' it hashes the contents from the hiera 'common_packages'
https://github.com/Talend/talend-cloud-installer/blob/ab6b7519b8b7e86a2922b6a9b8d275e4fb2263ac/site/profile/manifests/common/packages.pp#L11

In https://github.com/Talend/talend-cloud-installer/blob/ddacd4981dc9a4ebdc8bb348389db451cdd0b475/hieradata/common.yaml#L31-L34
I added the 2 new packages: Screen and LNAV, because we want them to be installed on every machine.