### PR TITLE
DEVOPS-4665 : upgrade puppet monitoring to reduce scraped data by cadvisor

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -52,5 +52,5 @@ mod 'puppetlabs-postgresql',
 mod 'puppetlabs-mongodb',
   :git => 'https://github.com/Talend/puppet-mongodb.git',
   :ref => '0.18.x'
-mod 'talend-monitoring', '0.1.0.16',
+mod 'talend-monitoring', '0.1.0.17',
   :github_tarball => 'Talend/puppet-monitoring'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -137,7 +137,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: Talend/puppet-monitoring
   specs:
-    talend-monitoring (0.1.0.16)
+    talend-monitoring (0.1.0.17)
 
 GITHUBTARBALL
   remote: Talend/puppet-syncope
@@ -188,7 +188,7 @@ DEPENDENCIES
   talend-cloudwatchlogs (~> 0.0)
   talend-dataprep_dataset (~> 0.0)
   talend-kafka (>= 0)
-  talend-monitoring (= 0.1.0.16)
+  talend-monitoring (= 0.1.0.17)
   talend-syncope (~> 0.0)
   talend-tic (~> 0.0)
   talend-user_accounts (~> 0.0)


### PR DESCRIPTION
More info in the jira : https://jira.talendforge.org/browse/DEVOPS-4665