### PR TITLE
DEVOPS-4572: provisioning karaf config to iPaaS services external

### DIFF
--- a/hieradata/puppet_role/tic_services_external.yaml
+++ b/hieradata/puppet_role/tic_services_external.yaml
@@ -150,6 +150,9 @@ tic::services::license_service_url: "%{::tmc_license_url}"
 tic::services::zipkin_kafka_servers: "%{::zipkin_kafka_servers}"
 tic::services::zipkin_kafka_topic: "%{::zipkin_kafka_topic}"
 
+tic::services::eventsource_kafka_servers: "%{::kafka_app_entry_point}"
+tic::services::eventsource_kafka_topic: "%{::provisioning_kafka_topic}"
+
 cloudwatchlog_files:
   "/talend/tic/%{::main_stack}/%{::puppet_role}/opt/talend/ipaas/rt-infra/data/log/karaf.log":
     path: '/opt/talend/ipaas/rt-infra/data/log/karaf.log'
@@ -195,4 +198,5 @@ tic::services::karaf_features_install:
   - 'tipaas-account-manager-service'
   - 'tipaas-tpsvc-crypto-client'
   - 'tpsvc-config-client'
+  - 'tipaas-kafkasource'
   - 'tipaas-healthcheck-service-core'


### PR DESCRIPTION
Added the same config as for internal services