### PR TITLE
DEVOPS-4959 - remove 'tipaas-account-manager' and 'tipaas-kafkasource' from Externa…

### DIFF
--- a/hieradata/puppet_role/tic_services_external.yaml
+++ b/hieradata/puppet_role/tic_services_external.yaml
@@ -195,8 +195,6 @@ tic::services::karaf_features_install:
   - 'tipaas-pairing-service'
   - 'tipaas-webhooks-service'
   - 'tipaas-logs-transfer-service-core'
-  - 'tipaas-account-manager-service'
   - 'tipaas-tpsvc-crypto-client'
   - 'tpsvc-config-client'
-  - 'tipaas-kafkasource'
   - 'tipaas-healthcheck-service-core'


### PR DESCRIPTION
Need to remove 'tipaas-account-manager' and 'tipaas-kafkasource' 
from External karaf.

Needed when enable async provisioning on production