### PR TITLE
DEVOPS-4905: Upgrade java to 1.8.0_181 for ActiveMQ

### DIFF
--- a/hieradata/puppet_role/activemq.yaml
+++ b/hieradata/puppet_role/activemq.yaml
@@ -1,8 +1,8 @@
 ---
 java::distribution: "jre"
-java::package: "jre1.8.0_60"
-java::version: "1.8.0_60-fcs"
-java::java_home: "/usr/java/jre1.8.0_60"
+java::package: "jre1.8"
+java::version: "1.8.0_181-fcs"
+java::java_home: "/usr/java/jre1.8.0_181-amd64"
 
 common_packages:
   'ptic-postgresql-schemes':

--- a/spec/acceptance/activemq_spec.rb
+++ b/spec/acceptance/activemq_spec.rb
@@ -4,4 +4,8 @@ describe 'role::activemq' do
   it_behaves_like 'profile::base'
   it_behaves_like 'profile::activemq'
   it_behaves_like 'role::defined', 'activemq'
+
+  describe package('jre1.8') do
+    it { should be_installed.with_version('1.8.0_181-fcs') }
+  end
 end


### PR DESCRIPTION
tested by local test run