### PR TITLE
DEVOPS-3766: switch to internal LB for webhooks service

### DIFF
--- a/hieradata/puppet_role/tic_services_internal.yaml
+++ b/hieradata/puppet_role/tic_services_internal.yaml
@@ -127,7 +127,7 @@ tic::services::kms_key_alias: "%{::kms_key_alias}"
 tic::services::zipkin_kafka_servers: "%{::zipkin_kafka_servers}"
 tic::services::zipkin_kafka_topic: "%{::zipkin_kafka_topic}"
 
-tic::services::webhooks_external_url: "%{::webhooks_host}"
+tic::services::webhooks_external_url: "http://%{::tic_services_external_nodes}:8181/services/webhooks-service"
 
 tic::services::eventsource_kafka_servers: "%{::kafka_app_entry_point}"
 tic::services::eventsource_kafka_topic: "%{::provisioning_kafka_topic}"


### PR DESCRIPTION
Idea is to use internal LB fro TIC Services external instead of special internet-faced LB for webhooks.
LTS service URL works in the same way.