### PR TITLE
DEVOPS-5160: mongodb upgrade

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,7 +31,7 @@ transport:
   name: sftp
 
 platforms:
-  - name: centos-7.4
+  - name: centos-7.5
 
 verifier:
   name: serverspec

--- a/Puppetfile
+++ b/Puppetfile
@@ -49,8 +49,7 @@ mod 'talend-user_accounts', '0.x',
 mod 'puppetlabs-postgresql',
   :git => 'https://github.com/Talend/puppetlabs-postgresql.git',
   :ref => 'master'
-mod 'puppetlabs-mongodb',
-  :git => 'https://github.com/Talend/puppet-mongodb.git',
-  :ref => '0.18.x'
+mod 'puppetlabs-mongodb', '0.18.1',
+  :github_tarball => 'Talend/puppet-mongodb'
 mod 'talend-monitoring', '0.1.0.17',
   :github_tarball => 'Talend/puppet-monitoring'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -86,15 +86,6 @@ GIT
       puppetlabs-stdlib (>= 4.11.0)
 
 GIT
-  remote: https://github.com/Talend/puppet-mongodb.git
-  ref: 0.18.x
-  sha: e59ad3a9c30fc68ea903c445c1a37ea1ce6e74ef
-  specs:
-    puppetlabs-mongodb (0.18.0)
-      puppetlabs-apt (< 3.0.0, >= 2.1.0)
-      puppetlabs-stdlib (< 5.0.0, >= 4.4.0)
-
-GIT
   remote: https://github.com/Talend/puppet-nexus.git
   ref: master
   sha: 7224a29b89e661eccfa1c2beacaf1e322e285536
@@ -133,6 +124,11 @@ GITHUBTARBALL
   remote: Talend/puppet-dataprep_dataset
   specs:
     talend-dataprep_dataset (0.1.0.5)
+
+GITHUBTARBALL
+  remote: Talend/puppet-mongodb
+  specs:
+    puppetlabs-mongodb (0.18.1)
 
 GITHUBTARBALL
   remote: Talend/puppet-monitoring
@@ -175,7 +171,7 @@ DEPENDENCIES
   puppetlabs-java (~> 1.0)
   puppetlabs-limits (~> 0.0)
   puppetlabs-lvm (~> 0.0)
-  puppetlabs-mongodb (>= 0)
+  puppetlabs-mongodb (= 0.18.1)
   puppetlabs-ntp (~> 4.0)
   puppetlabs-postgresql (>= 0)
   puppetlabs-stdlib (~> 4.0)

--- a/hieradata/puppet_role/mongodb.yaml
+++ b/hieradata/puppet_role/mongodb.yaml
@@ -92,7 +92,7 @@ cloudwatchlog_files:
 # IPAAS MongoDB replicaset profile
 mongodb_default_profile:
   replset_name: 'tipaas'
-  storage_engine: 'mmapv1'
+  storage_engine: 'wiredTiger'
   users:
     admin:
       db_address: 'ipaas'

--- a/site/profile/files/etc/systemd/system/mongod.service
+++ b/site/profile/files/etc/systemd/system/mongod.service
@@ -1,0 +1,4 @@
+# File managed by Puppet, do not edit manually
+.include /usr/lib/systemd/system/mongod.service
+[Service]
+Type=simple

--- a/site/profile/manifests/mongodb.pp
+++ b/site/profile/manifests/mongodb.pp
@@ -201,6 +201,17 @@ class profile::mongodb (
     content => ":programname,contains,\"mongod\" /var/log/mongodb/mongod.log;CloudwatchAgentEOL\n& stop",
   }
 
+  file { 'systemd-mongod-override':
+    ensure  => file,
+    path    => '/etc/systemd/system/mongod.service',
+    source  => 'puppet:///modules/profile/etc/systemd/system/mongod.service',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    require => Package['mongodb_server'],
+    before  => Class['mongodb::server::service']
+  }
+
 
 
   class { '::mongodb::client':

--- a/spec/acceptance/shared/mongodb.rb
+++ b/spec/acceptance/shared/mongodb.rb
@@ -21,6 +21,17 @@ shared_examples 'profile::mongodb' do
     end
   end
 
+  describe 'Verifying mongod systemd override' do
+    describe file('/etc/systemd/system/mongod.service') do
+      it { should be_file }
+      its(:content) { should include '# File managed by Puppet, do not edit manually' }
+      its(:content) { should include 'Type=simple' }
+    end
+    describe command('/bin/systemctl --no-pager show mongod.service') do
+      its(:stdout) { should include 'Type=simple' }
+    end
+  end
+
   describe 'Verifying swap' do
     describe file('/var/lib/mongo/mongo.swap') do
       it { should be_file }
@@ -32,7 +43,7 @@ shared_examples 'profile::mongodb' do
 
   describe 'Verify MongoDB major version and facts' do
     describe command('/usr/bin/facter -p mongodb_version') do
-      its(:stdout) { is_expected.to match(/^[2-3]/) }
+      its(:stdout) { is_expected.to match(/^[3]/) }
     end
     describe command('/usr/bin/facter -p mongodb_is_master') do
       # with auth enabled, the mongodb facter can't connect
@@ -186,6 +197,13 @@ shared_examples 'profile::mongodb' do
       it { should be_file }
       its(:content) { should include '# THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.' }
       its(:content) { should include ' /etc/logrotate.d/hourly ' }
+    end
+  end
+
+  describe 'credential storage' do
+    describe file('/root/.mongorc.js') do
+      it { should be_file }
+      its(:content) { should include ' db.auth(\'sreadmin\', \'mypassword\')' }
     end
   end
 


### PR DESCRIPTION
tested locally with:
`./scripts/local_dev_tests.sh -t role-mongodb-centos-75`
 `./scripts/local_dev_tests.sh -t role-mongodb-versioned-centos-75`
`./scripts/local_dev_tests.sh -t role-mongodb-tds-profile-centos-75`

All tests successfull. We need to modify extrafile before applying it in master to prepare migration.
