### PR TITLE
update Kafka to 1.1.1

### DIFF
--- a/site/profile/manifests/kafka.pp
+++ b/site/profile/manifests/kafka.pp
@@ -3,7 +3,7 @@
 #
 
 class profile::kafka (
-  $kafka_version           = '0.10.2.1',
+  $kafka_version           = '1.1.1',
   $scala_version           = '2.11',
   $kafka_datapath          = '/var/lib/kafka',
   $storage_device          = undef,
@@ -44,7 +44,8 @@ class profile::kafka (
     'zookeeper.connect'             => $zookeeper_connect,
     'log.dir'                       => $kafka_datapath,
     'log.dirs'                      => $kafka_datapath,
-    'inter.broker.protocol.version' => $kafka_version,
+    'inter.broker.protocol.version' => $kafka_version, #for rolling update, override in extrafile
+    'log.message.format.version'    => $kafka_version, #for rolling update, override in extrafile
     'advertised.host.name'          => $::ipaddress,
     'auto.create.topics.enable'     => $kafka_topics_autocreate,
     'log.cleanup.policy'            => 'delete',


### PR DESCRIPTION
tested with
```
./scripts/local_dev_tests.sh -t role-kafka-centos-75
...
role::kafka
  behaves like profile::base
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "base"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatch
      File "/opt/cloudwatch-agent/metrics.yaml"
        content
          should include "  metrics:"
        content
          should include "    DiskSpace:"
      File "/var/spool/cron/cloudwatch-agent"
        content
          should include "# Puppet Name: CloudWatch Agent"
        content
          should include "/opt/cloudwatch-agent/cw_agent.py --metrics /opt/cloudwatch-agent/metrics.yaml"
    behaves like profile::common::cloudwatchlogs
      behaves like profile::common::cloudwatchlog_files
        Service "awslogs"
          configuration [/etc/awslogs/awslogs.conf]
            should include "file = /var/log/audit/audit.log"
            should include "file = /var/log/messages"
            should include "file = /var/log/secure"
      Service "awslogs"
        should be enabled
        should be running
    behaves like profile::common::ssm
      Package "amazon-ssm-agent"
        should be installed
    behaves like monitoring::node_exporter
      User "node_exporter"
        should exist
      Service "node_exporter.service"
        should be enabled
        should be running
      Command "/usr/bin/curl -v http://127.0.0.1:9100/metrics"
        exit_status
          should eq 0
        stdout
          should include "node_filesystem_size"
    ntp configuration
      should include "restrict default nomodify notrap nopeer noquery"
      should include "server 0.amazon.pool.ntp.org iburst"
      should include "server 1.amazon.pool.ntp.org iburst"
      should include "server 2.amazon.pool.ntp.org iburst"
      should include "server 3.amazon.pool.ntp.org iburst"
    ntp sync
      should include "synchronised to"
      should include "time correct to within"
  behaves like profile::kafka
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "kafka"
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatchlog_files
      Service "awslogs"
        configuration [/etc/awslogs/awslogs.conf]
          should include "file = /opt/kafka/logs/server.log"
          should include "file = /opt/kafka/logs/state-change.log"
          should include "file = /opt/kafka/logs/kafka-request.log"
          should include "file = /opt/kafka/logs/log-cleaner.log"
          should include "file = /opt/kafka/logs/controller.log"
          should include "file = /opt/kafka/logs/kafka-authorizer.log"
    Service "kafka"
      should be enabled
      should be running
    Port "9092"
      should be listening
    Port "9990"
      should be listening
    File "/var/lib/kafka"
      should be mounted
    Log4j configuration
      should include "managed by Puppet"
    Cloudwatch Kafka specific
      should include "    DiskSpaceKafka:"
    Verifying topic creation on zookeeper 'localhost:2181/testing-kafka'
      should include "dispatcher"
      should include "container-manager"
      should include "container-events"
      should not include "tpsvclogs"
      should not include "zipkin"
      should include "provisioning"
    Verifying topic creation on zookeeper 'localhost:2181/testing-kafka' for dataprep
      should include "dataprep"
      should include "dataprep-unique"
      should include "dataprep-broadcast"
    Verifying topic sharding on zookeeper 'localhost:2181/testing-kafka' for dispatcher
      should include "Topic:dispatcher"
      should include "PartitionCount:2"
      should include "ReplicationFactor:1"
    Verifying topic configuration on zookeeper 'localhost:2181/testing-kafka' for dispatcher
      should include "retention.bytes=536870912"
    Verifying topic configuration on zookeeper 'localhost:2181/testing-kafka' for dqDictionary
      should include "retention.bytes=6442450944"
    Sending test message to tpsvclogs
      should eq 0
    Getting test message
      exit_status
        should eq 143
      stdout
        should include "this is a very bad test message"
    Verifying no DEBUG messages in /var/log/messages
      should not include " DEBUG "
  behaves like role::defined
    File "/etc/sysconfig/puppetRole"
      should be file
      content
        should include "kafka"

Finished in 36.26 seconds (files took 0.81972 seconds to load)
73 examples, 0 failures
...
```
