### PR TITLE
DEVOPS-5417: increase MongoDB nofile and nproc

### DIFF
--- a/site/profile/files/etc/security/limits.d/mongod.conf
+++ b/site/profile/files/etc/security/limits.d/mongod.conf
@@ -5,7 +5,7 @@ mongod  soft    cpu     unlimited
 mongod  hard    cpu     unlimited
 mongod  soft    as      unlimited
 mongod  hard    as      unlimited
-mongod  soft    nofile  64000
-mongod  hard    nofile  64000
-mongod  soft    nproc   64000
-mongod  hard    nproc   64000
+mongod  soft    nofile  128000
+mongod  hard    nofile  128000
+mongod  soft    nproc   128000
+mongod  hard    nproc   128000

--- a/site/profile/files/etc/sysctl.d/mongod.conf
+++ b/site/profile/files/etc/sysctl.d/mongod.conf
@@ -1,6 +1,6 @@
 # File managed by Puppet, do not edit manually
 vm.zone_reclaim_mode=0
 net.ipv4.tcp_keepalive_time=120
-fs.file-max=98384
-kernel.pid_max=64000
-kernel.threads-max=64000
+fs.file-max=500000
+kernel.pid_max=128000
+kernel.threads-max=128000

--- a/site/profile/files/etc/systemd/system/mongod.service
+++ b/site/profile/files/etc/systemd/system/mongod.service
@@ -2,3 +2,7 @@
 .include /usr/lib/systemd/system/mongod.service
 [Service]
 Type=simple
+# open files
+LimitNOFILE=128000
+# processes/threads
+LimitNPROC=128000

--- a/spec/acceptance/shared/mongodb.rb
+++ b/spec/acceptance/shared/mongodb.rb
@@ -13,11 +13,14 @@ shared_examples 'profile::mongodb' do
       its(:content) { should include '# File managed by Puppet, do not edit manually' }
     end
     describe command('/sbin/sysctl -a') do
-      its(:stdout) { should include 'kernel.pid_max = 64000' }
-      its(:stdout) { should include 'kernel.threads-max = 64000' }
-      its(:stdout) { should include 'fs.file-max = 98384' }
+      its(:stdout) { should include 'kernel.pid_max = 128000' }
+      its(:stdout) { should include 'kernel.threads-max = 128000' }
+      its(:stdout) { should include 'fs.file-max = 500000' }
       its(:stdout) { should include 'net.ipv4.tcp_keepalive_time = 120' }
       its(:stdout) { should include 'vm.zone_reclaim_mode = 0' }
+    end
+    describe command('/bin/cat /proc/sys/fs/file-max') do
+      its(:stdout) { should include '500000' }
     end
   end
 
@@ -26,9 +29,13 @@ shared_examples 'profile::mongodb' do
       it { should be_file }
       its(:content) { should include '# File managed by Puppet, do not edit manually' }
       its(:content) { should include 'Type=simple' }
+      its(:content) { should include 'LimitNOFILE=128000' }
+      its(:content) { should include 'LimitNPROC=128000' }
     end
     describe command('/bin/systemctl --no-pager show mongod.service') do
       its(:stdout) { should include 'Type=simple' }
+      its(:stdout) { should include 'LimitNOFILE=128000' }
+      its(:stdout) { should include 'LimitNPROC=128000' }
     end
   end
 
@@ -84,11 +91,12 @@ shared_examples 'profile::mongodb' do
     describe file('/etc/security/limits.d/mongod.conf') do
       it { should be_file }
       its(:content) { should include '# File managed by Puppet, do not edit manually' }
-      its(:content) { should match /\nmongod\s+soft\s+nproc\s+64000\s*\n/ }
-      its(:content) { should match /\nmongod\s+hard\s+nproc\s+64000\s*\n/ }
+      its(:content) { should match /\nmongod\s+soft\s+nproc\s+128000\s*\n/ }
+      its(:content) { should match /\nmongod\s+hard\s+nproc\s+128000\s*\n/ }
     end
     describe command('/bin/bash -c \'/bin/cat /proc/$(/bin/pgrep -x mongod)/limits\'') do
-      its(:stdout) { should include 'Max processes             64000                64000                processes' }
+      its(:stdout) { should match /\nMax processes\s+128000\s+128000\s+processes\s*\n/ }
+      its(:stdout) { should match /\nMax open files\s+128000\s+128000\s+files\s*\n/ }
     end
   end
 


### PR DESCRIPTION
Tested locally
```
./scripts/local_dev_tests.sh -t role-mongodb-centos-75
...
role::mongodb
  behaves like profile::base
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "base"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatchlogs
      behaves like profile::common::cloudwatchlog_files
        Service "awslogs"
          configuration [/etc/awslogs/awslogs.conf]
            should include "file = /var/log/audit/audit.log"
            should include "file = /var/log/messages"
            should include "file = /var/log/secure"
      Service "awslogs"
        should be enabled
        should be running
    behaves like profile::common::ssm
      Package "amazon-ssm-agent"
        should be installed
    behaves like monitoring::node_exporter
      User "node_exporter"
        should exist
      Service "node_exporter.service"
        should be enabled
        should be running
      Command "/usr/bin/curl -v http://127.0.0.1:9100/metrics"
        exit_status
          should eq 0
        stdout
          should include "node_filesystem_size"
    ntp configuration
      should include "restrict default nomodify notrap nopeer noquery"
      should include "server 0.amazon.pool.ntp.org iburst"
      should include "server 1.amazon.pool.ntp.org iburst"
      should include "server 2.amazon.pool.ntp.org iburst"
      should include "server 3.amazon.pool.ntp.org iburst"
    ntp sync
      should include "synchronised to"
      should include "time correct to within"
  behaves like profile::rsyslog
    Verifying rsyslog conf
      File "/etc/rsyslog.conf"
        should be file
        content
          should include "# file is managed by puppet"
        content
          should include "$IncludeConfig /etc/rsyslog.d/*.conf"
    Verifying default logging
      File "/etc/rsyslog.d/00_client.conf"
        should be file
        content
          should include "# This file is managed by Puppet, changes may be overwritten"
        content
          should include "$template CloudwatchAgent,"
        content
          should include "$template CloudwatchAgentEOL,"
        content
          should not include "/var/log/messages"
      File "/etc/rsyslog.d/99_local_logs.conf"
        should be file
        content
          should include "# This file is managed by Puppet, changes may be overwritten"
        content
          should include "/var/log/messages"
    Service "rsyslog"
      should be enabled
      should be running
  behaves like profile::mongodb
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "mongodb"
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatchlog_files
      Service "awslogs"
        configuration [/etc/awslogs/awslogs.conf]
          should include "file = /var/log/mongodb/mongod.log"
    Verifying mongod sysctl conf
      File "/etc/sysctl.d/mongod.conf"
        should be file
        content
          should include "# File managed by Puppet, do not edit manually"
      Command "/sbin/sysctl -a"
        stdout
          should include "kernel.pid_max = 128000"
        stdout
          should include "kernel.threads-max = 128000"
        stdout
          should include "fs.file-max = 500000"
        stdout
          should include "net.ipv4.tcp_keepalive_time = 120"
        stdout
          should include "vm.zone_reclaim_mode = 0"
      Command "/bin/cat /proc/sys/fs/file-max"
        stdout
          should include "500000"
    Verifying mongod systemd override
      File "/etc/systemd/system/mongod.service"
        should be file
        content
          should include "# File managed by Puppet, do not edit manually"
        content
          should include "Type=simple"
        content
          should include "LimitNOFILE=128000"
        content
          should include "LimitNPROC=128000"
      Command "/bin/systemctl --no-pager show mongod.service"
        stdout
          should include "Type=simple"
        stdout
          should include "LimitNOFILE=128000"
        stdout
          should include "LimitNPROC=128000"
    Verifying swap
      File "/var/lib/mongo/mongo.swap"
        should be file
      Command "/sbin/swapon"
        stdout
          should include "/var/lib/mongo/mongo.swap file"
    Verify MongoDB major version and facts
      Command "/usr/bin/facter -p mongodb_version"
        stdout
          should match /^[3]/
      Command "/usr/bin/facter -p mongodb_is_master"
        stdout
          should match /^(unknown)|(true)\n/
    mongod hugepages off
      Command "/sbin/tuned-adm active"
        stdout
          should include "No current active profile."
      File "/etc/init.d/disable-transparent-hugepages"
        should be file
        content
          should include "# File managed by Puppet, do not edit manually"
      Command "/sbin/chkconfig --list"
        stdout
          should include "disable-transparent-hugepages"
      Command "/bin/cat /sys/kernel/mm/transparent_hugepage/enabled"
        stdout
          should include "always madvise [never]"
      Command "/bin/cat /sys/kernel/mm/transparent_hugepage/defrag"
        stdout
          should include "always madvise [never]"
    Verifying mongod conf
      File "/etc/mongod.conf"
        should be file
        content
          should include "#mongodb.conf - generated from Puppet"
        content
          should include "#System Log"
        content
          should include "systemLog.destination: syslog"
    Verifying mongod ulimits
      File "/etc/security/limits.d/mongod.conf"
        should be file
        content
          should include "# File managed by Puppet, do not edit manually"
        content
          should match /\nmongod\s+soft\s+nproc\s+128000\s*\n/
        content
          should match /\nmongod\s+hard\s+nproc\s+128000\s*\n/
      Command "/bin/bash -c '/bin/cat /proc/$(/bin/pgrep -x mongod)/limits'"
        stdout
          should match /\nMax processes\s+128000\s+128000\s+processes\s*\n/
        stdout
          should match /\nMax open files\s+128000\s+128000\s+files\s*\n/
    Verifying mongodb logging
      File "/etc/rsyslog.d/10_mongod.conf"
        should be file
        content
          should include "# This file is managed by Puppet, changes may be overwritten"
      File "/var/log/mongodb/mongod.log"
        should be file
      Command "/bin/test $(/bin/egrep '^[a-zA-Z]{3} ([0-9]{2}| [0-9]) [0-9]{2}:[0-9]{2}:[0-9]{2} ' /var/log/mongodb/mongod.log | /bin/wc -l) -gt 3"
        exit_status
          should eq 0
      Command "/bin/test $(/bin/egrep '^\s*$' /var/log/mongodb/mongod.log | /bin/wc -l) -eq 0"
        exit_status
          should eq 0
    Verifying mongodb auth
      File "/var/lib/mongo/mongo_auth.flag"
        should be file
      File "/etc/mongod.conf"
        should be file
        content
          should include "security.authorization: enabled"
      Command "/usr/bin/mongo --norc --quiet -u sreadmin -p mypassword admin --eval "db.help();""
        exit_status
          should eq 0
      Command "/usr/bin/mongo --norc --quiet -u sreadmin -p mybadpassword admin --eval "db.help();""
        exit_status
          should eq 1
    Service "mongod"
      should be enabled
      should be running
    Package "mongodb-org-tools"
      should be installed
    Port "27017"
      should be listening
    File "/var/lib/mongo"
      should be mounted
    Command "/usr/bin/lsblk -o KNAME,SIZE,FSTYPE -n /dev/sdb"
      stdout
        should include "sdb"
      stdout
        should include "10G"
      stdout
        should include "xfs"
    Command "/usr/bin/mongo --norc --quiet -u sreadmin -p mypassword admin --eval "printjson(db.getUser('sreadmin'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"userAdmin\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"readWrite\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"dbAdmin\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"dbAdminAnyDatabase\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"readAnyDatabase\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"readWriteAnyDatabase\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"userAdminAnyDatabase\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"clusterAdmin\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"clusterManager\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"clusterMonitor\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"hostManager\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"root\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"restore\",\"db\":\"admin\"}"
    Command "/usr/bin/mongo --norc --quiet -u backup -p mypassword admin --eval "printjson(db.getUser('backup'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"backupRole\",\"db\":\"admin\"}"
    Command "/usr/bin/mongo --norc --quiet -u monitor -p mypassword admin --eval "printjson(db.getUser('monitor'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"clusterMonitor\",\"db\":\"admin\"}"
    Command "/usr/bin/mongo --norc --quiet -u datadog -p mypassword admin --eval "printjson(db.getUser('datadog'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"clusterMonitor\",\"db\":\"admin\"}"
    Logrotate configuration
      File "/etc/logrotate.d/hourly/mongodb_log"
        should be file
        content
          should include "# THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET."
        content
          should include "/var/log/mongodb/mongod.log"
        content
          should include "compress"
      File "/etc/cron.hourly/logrotate"
        should be file
        content
          should include "# THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET."
        content
          should include " /etc/logrotate.d/hourly "
    credential storage
      File "/root/.mongorc.js"
        should be file
        content
          should include " db.auth('sreadmin', 'mypassword')"
    Host "mongo0.com"
      should be resolvable
    Host "mongo0.net"
      should be resolvable
    Host "mongo0.org"
      should be resolvable
    Host "mongo0.io"
      should be resolvable
    Host "mongo1.com"
      should be resolvable
    Host "mongo1.net"
      should be resolvable
    Host "mongo1.org"
      should be resolvable
    Host "mongo1.io"
      should be resolvable
    Mongodb exporter
      User "mongodb_exporter"
        should exist
      Service "mongodb_exporter.service"
        should be enabled
        should be running
      Command "/usr/bin/curl -v http://127.0.0.1:9216/metrics"
        exit_status
          should eq 0
        stdout
          should include "mongodb_mongod_storage_engine"
  behaves like profile::mongodb_default_profile
    Command "/usr/bin/mongo --norc --quiet -u admin -p mypassword ipaas --eval "printjson(db.getUser('admin'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"userAdminAnyDatabase\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"dbAdminAnyDatabase\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"readWriteAnyDatabase\",\"db\":\"admin\"}"
      stdout
        should include "{\"role\":\"dbOwner\",\"db\":\"ipaas\"}"
    Command "/usr/bin/mongo --norc --quiet -u tpsvc_config -p mypassword configuration --eval "printjson(db.getUser('tpsvc_config'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"dbOwner\",\"db\":\"configuration\"}"
    Command "/usr/bin/mongo --norc --quiet -u dqdict-user -p mypassword dqdict --eval "printjson(db.getUser('dqdict-user'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"dbOwner\",\"db\":\"dqdict\"}"
    Command "/usr/bin/mongo --norc --quiet -u tpsvc_provisioning -p mypassword provisioning --eval "printjson(db.getUser('tpsvc_provisioning'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"dbOwner\",\"db\":\"provisioning\"}"
    Command "/usr/bin/mongo --norc --quiet -u tpsvc_dispatcher_events -p mypassword dispatcher_events --eval "printjson(db.getUser('tpsvc_dispatcher_events'));" | /usr/bin/tr -d "\t\n ""
      stdout
        should include "{\"role\":\"dbOwner\",\"db\":\"dispatcher_events\"}"
  behaves like role::defined
    File "/etc/sysconfig/puppetRole"
      should be file
      content
        should include "mongodb"

Finished in 12.45 seconds (files took 0.32446 seconds to load)
152 examples, 0 failures

       Finished verifying <role-mongodb-centos-75> (0m13.11s).
-----> Destroying <role-mongodb-centos-75>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-mongodb-centos-75> destroyed.
       Finished destroying <role-mongodb-centos-75> (0m3.28s).
       Finished testing <role-mongodb-centos-75> (7m24.23s).
-----> Kitchen is finished. (7m24.43s)
```