### PR TITLE
db optimizations optionnals

### DIFF
--- a/site/profile/manifests/activemq.pp
+++ b/site/profile/manifests/activemq.pp
@@ -1,7 +1,9 @@
 #
 # ActiveMQ service profile
 #
-class profile::activemq {
+class profile::activemq(
+  $with_postgresql_optimizations = true,
+){
 
   require ::profile::common::packagecloud_repos
   require ::profile::java
@@ -27,9 +29,15 @@ class profile::activemq {
     if (( $::activemq::persistence == 'postgres')
       and (($::activemq::service_ensure == 'running')
         or ($::activemq::service_ensure == 'true'))) {
+      if (str2bool($with_postgresql_optimizations)) {
         class { '::profile::postgresql::activemq':
           require => Class['::activemq']
         }
+      } else {
+        notify{'Database optimizations explicitely ignored':
+          require => Class['::activemq']
+        }
+      }
     }
 
   } else {


### PR DESCRIPTION
tested locally:
```
λ git diff hieradata/environment/vagrant.yaml
diff --git a/hieradata/environment/vagrant.yaml b/hieradata/environment/vagrant.yaml
index 5a65325..7d430d0 100644
--- a/hieradata/environment/vagrant.yaml
+++ b/hieradata/environment/vagrant.yaml
@@ -50,6 +50,7 @@ postgresql::globals::default_connect_settings:
 
 activemq::pg_host: "localhost"
 activemq::persistence_pg_host: "localhost"
+profile::activemq::with_postgresql_optimizations: false
 # The dict above must be the same than the one inside hieradata/puppet_role/activemq.yaml
 # + activemq
 profile::postgresql::roles:
```
then it's failing on activemq optimizations verifications as expected

```
./scripts/local_dev_tests.sh -t role-activemq-centos-75
...
Notice: Database optimizations explicitely ignored
Notice: /Stage[main]/Profile::Activemq/Notify[Database optimizations explicitely ignored]/message: defined 'message' as 'Database optimizations explicitely ignored'
...
Finished in 6.12 seconds (files took 0.27094 seconds to load)
60 examples, 13 failures

Failed examples:

rspec ./spec/acceptance/activemq_spec.rb[1:2:9:1:1] # role::activemq behaves like profile::activemq ActiveMQ optimization version table stdout should include "0.1"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:1:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "tmp_activemq_msgs_p_desc_idx"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:2:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "tmp_activemq_msgs_pc_asc_idx"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:3:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "tmp_activemq_msgs_pcx_asc_idx"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:4:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "tmp_activemq_msgs_pcp_idx"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:5:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "tmp_activemq_msgs_pxpc_asc_desc_idx"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:6:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "autovacuum_vacuum_cost_limit=2000"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:7:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "autovacuum_vacuum_cost_delay=10"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:8:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "autovacuum_vacuum_scale_factor=0"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:9:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "autovacuum_vacuum_threshold=5000"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:10:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "autovacuum_analyze_threshold=1000"
rspec ./spec/acceptance/activemq_spec.rb[1:2:12:11:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_msgs content should include "autovacuum_analyze_scale_factor=0.01"
rspec ./spec/acceptance/activemq_spec.rb[1:2:13:1:1] # role::activemq behaves like profile::activemq verifying ActiveMQ optimizations for activemq_acks content should include "tmp_activemq_acks_c_idx"
```