### PR TITLE
DEVOPS-4884 fix user/group pb in kafka ami

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -94,4 +94,5 @@ monitoring::mongodb_exporter::version: '0.3.1'
 monitoring::mongodb_exporter::port: 9216
 
 monitoring::jmx_exporter::version: '0.3.1'
+monitoring::jmx_exporter::user: 'root'
 jmx_exporter_port: 9404


### PR DESCRIPTION
There is an issue in ami, some files/dirs. will be created by the newly created user if not specified in  puppet code. It will cause permission issue on file access, e.g. user/group should be kafka not jmx_exporter/cbiermann.
bash-4.2# ls -l /var/lib/kafka
total 136
rw-rr- 1 jmx_exporter cbiermann 62 1月 15 09:31 cleaner-offset-checkpoint
drwxr-xr-x 2 jmx_exporter cbiermann 141 9月 13 15:13 __consumer_offsets-0
drwxr-xr-x 2 jmx_exporter cbiermann 141 9月 13 15:13 __consumer_offsets-1
drwxr-xr-x 2 jmx_exporter cbiermann 141 9月 13 15:13 __consumer_offsets-10
drwxr-xr-x 2 jmx_exporter cbiermann 141 9月 13 15:14 __consumer_offsets-11
drwxr-xr-x 2 jmx_exporter cbiermann 141 9月 13 15:14 __consumer_offsets-12


This issue is not caused by jmx_exporter module, it happens just because the user jmx_exporter is created first. Other example is node_exporter on kafka node

ls -l /opt/node_exporter-0.15.2.linux-amd64
drwxrwxr-x   2 kafka    qa           4096 12月  5 2017 node_exporter-0.15.2.linux-amd64

The user/group should be node_exporter as specified in puppet code, but in the fact it is kafka/qa??


 