### PR TITLE
DEVOPS-4884 fix jmx_exporter class dependency pb

### DIFF
--- a/site/profile/manifests/activemq.pp
+++ b/site/profile/manifests/activemq.pp
@@ -11,7 +11,10 @@ class profile::activemq(
 
   include ::profile::common::concat
   include ::profile::common::cloudwatchlogs
-  include monitoring::jmx_exporter
+
+  class { '::monitoring::jmx_exporter':
+    before => Class['::activemq'],
+  }
 
   profile::register_profile { 'activemq': }
 

--- a/site/profile/manifests/kafka.pp
+++ b/site/profile/manifests/kafka.pp
@@ -25,7 +25,10 @@ class profile::kafka (
   include ::logrotate
   include ::profile::common::concat
   include ::profile::common::cloudwatchlogs
-  include monitoring::jmx_exporter
+
+  class { '::monitoring::jmx_exporter':
+    before => Class['::kafka'],
+  }
 
   profile::register_profile { 'kafka': }
 

--- a/site/profile/manifests/zookeeper.pp
+++ b/site/profile/manifests/zookeeper.pp
@@ -12,7 +12,10 @@ class profile::zookeeper (
 
   include ::profile::common::concat
   include ::profile::common::cloudwatchlogs
-  include monitoring::jmx_exporter
+
+  class { '::monitoring::jmx_exporter':
+    before => Class['::zookeeper'],
+  }
 
   profile::register_profile { 'zookeeper': }
 


### PR DESCRIPTION
 jmx_exporter should be installed before kafka/zookeepr/activemq, otherwise when kafka/zookeepr/activemq service is started with agent, the jmx jar/config file may not be ready.