### PR TITLE
DEVOPS-4884 Fix ownership pb in mount for kafka

### DIFF
--- a/site/profile/manifests/kafka.pp
+++ b/site/profile/manifests/kafka.pp
@@ -133,12 +133,14 @@ class profile::kafka (
     notify  => Service['kafka']
   }
 
-  class { '::profile::common::mount_device::fixup_ownership':
-    path    => $kafka_datapath,
-    owner   => 'kafka',
-    group   => 'kafka',
-    require => [ User['kafka'], Group['kafka'] ],
-    notify  => Service['kafka']
+  if $storage_device {
+    class { '::profile::common::mount_device::fixup_ownership':
+      path    => $kafka_datapath,
+      owner   => 'kafka',
+      group   => 'kafka',
+      require => [ User['kafka'], Group['kafka'] ],
+      notify  => Service['kafka']
+    }
   }
 
   file { '/opt/kafka/config/log4j.properties':

--- a/site/profile/manifests/kafka.pp
+++ b/site/profile/manifests/kafka.pp
@@ -133,6 +133,14 @@ class profile::kafka (
     notify  => Service['kafka']
   }
 
+  class { '::profile::common::mount_device::fixup_ownership':
+    path    => $kafka_datapath,
+    owner   => 'kafka',
+    group   => 'kafka',
+    require => [ User['kafka'], Group['kafka'] ],
+    notify  => Service['kafka']
+  }
+
   file { '/opt/kafka/config/log4j.properties':
     ensure  => 'present',
     owner   => 'kafka',


### PR DESCRIPTION
According to many tests I did, there is a common issue in device mount. The ownership of files under mount device is random. We already have such a fix in https://github.com/Talend/talend-cloud-installer/blob/master/site/profile/manifests/common/mount_device/fixup_ownership.pp, and it is used in mongo profile which needs to mount device also. https://github.com/Talend/talend-cloud-installer/blob/master/site/profile/manifests/mongodb.pp#L269


Here is  the ownership of files under /var/lib/kafka, sometimes it's right kafka:kafka, so it's random.
drwxr-xr-x 2 1000 1027   178 1月  17 10:37 userflow-changed-8
drwxr-xr-x 2 1000 1027   141 9月  13 17:30 websocket-to-app-0
drwxr-xr-x 2 1000 1027   178 1月  17 13:37 websocket-to-app-1
drwxr-xr-x 2 1000 1027   178 1月  17 14:07 websocket-to-app-10


-rw-r--r-- 1 1001 1028  1536 1月  18 09:26 recovery-point-offset-checkpoint
-rw-r--r-- 1 1001 1028  1536 1月  18 09:26 replication-offset-checkpoint
drwxr-xr-x 2 1001 1028  4096 1月  18 09:26 tpsvclogs-1
drwxr-xr-x 2 1001 1028  4096 1月  18 09:26 tpsvclogs-10
drwxr-xr-x 2 1001 1028  4096 1月  18 09:26 tpsvclogs-11


tested on talend-cloud-integartion