### PR TITLE
fix(ECS): fix Node Exporter error logs on ECS instances

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -49,5 +49,5 @@ mod 'puppetlabs-postgresql',
   :ref => 'master'
 mod 'puppetlabs-mongodb', '0.18.1',
   :github_tarball => 'Talend/puppet-mongodb'
-mod 'talend-monitoring', '0.1.0.21',
+mod 'talend-monitoring', '0.1.0.22',
   :github_tarball => 'Talend/puppet-monitoring'


### PR DESCRIPTION
* use latest puppet-monitoring
* don't monitor Docker filesystems (leave that to Cadvisor)