### PR TITLE
fix(MongoDB): add missing rights for MongoDB exporter user

### DIFF
--- a/hieradata/puppet_role/mongodb.yaml
+++ b/hieradata/puppet_role/mongodb.yaml
@@ -53,6 +53,8 @@ profile::mongodb::users:
     roles:
       - role: 'clusterMonitor'
         db: 'admin'
+      - role: 'read'
+        db: 'local'
   datadog:
     db_address: 'admin'
     username: 'datadog'


### PR DESCRIPTION
* MongoDB exporter uses also the 'read' permission on 'local' database