### PR TITLE
Devops-6319: zookeeper fix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,8 @@ provisioner:
     sudo yum clean all
     sudo rpm -U --replacepkgs http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
     sudo yum install -y puppet python-pip python-devel policycoreutils-devel cloud-init
+    sudo puppet module install camptocamp-ruby && sudo puppet apply -e "include ruby::gems"
+    sudo puppet module install camptocamp-augeas && sudo puppet apply -e "include ::augeas"
     sudo gem install aws-sdk hiera-eyaml hiera-eyaml-kms --no-ri --no-rdoc
   custom_facts:
     main_stack: test_main
@@ -37,7 +39,7 @@ transport:
   name: sftp
 
 platforms:
-  - name: centos-7.5
+  - name: centos-7.6
 
 verifier:
   name: serverspec
@@ -179,6 +181,8 @@ suites:
         sudo yum clean all
         sudo rpm -U --replacepkgs http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
         sudo yum install -y puppet python-pip python-devel policycoreutils-devel cloud-init
+        sudo puppet module install camptocamp-ruby && sudo puppet apply -e "include ruby::gems"
+        sudo puppet module install camptocamp-augeas && sudo puppet apply -e "include ::augeas"
         sudo gem install aws-sdk hiera-eyaml hiera-eyaml-kms --no-ri --no-rdoc
       custom_facts:
         puppet_role: mongodb
@@ -205,6 +209,8 @@ suites:
         sudo yum clean all
         sudo rpm -U --replacepkgs http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
         sudo yum install -y puppet python-pip python-devel policycoreutils-devel cloud-init
+        sudo puppet module install camptocamp-ruby && sudo puppet apply -e "include ruby::gems"
+        sudo puppet module install camptocamp-augeas && sudo puppet apply -e "include ::augeas"
         sudo gem install aws-sdk hiera-eyaml hiera-eyaml-kms --no-ri --no-rdoc
       custom_facts:
         puppet_role: mongodb
@@ -232,6 +238,8 @@ suites:
         sudo yum clean all
         sudo rpm -U --replacepkgs http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
         sudo yum install -y puppet python-pip python-devel policycoreutils-devel cloud-init
+        sudo puppet module install camptocamp-ruby && sudo puppet apply -e "include ruby::gems"
+        sudo puppet module install camptocamp-augeas && sudo puppet apply -e "include ::augeas"
         sudo gem install aws-sdk hiera-eyaml hiera-eyaml-kms --no-ri --no-rdoc
       custom_facts:
         puppet_role: mongodb

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -148,7 +148,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: Talend/puppet-zookeeper
   specs:
-    talend-zookeeper (0.1.1.14)
+    talend-zookeeper (0.1.1.15)
 
 DEPENDENCIES
   camptocamp-accounts (~> 1.0)

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -128,7 +128,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: Talend/puppet-monitoring
   specs:
-    talend-monitoring (0.1.0.21)
+    talend-monitoring (0.1.0.22)
 
 GITHUBTARBALL
   remote: Talend/puppet-syncope
@@ -178,7 +178,7 @@ DEPENDENCIES
   talend-cloudwatchlogs (~> 0.0)
   talend-dataprep_dataset (~> 0.0)
   talend-kafka (>= 0)
-  talend-monitoring (= 0.1.0.21)
+  talend-monitoring (= 0.1.0.22)
   talend-syncope (~> 0.0)
   talend-tic (~> 0.0)
   talend-user_accounts (~> 0.0)

--- a/hieradata/puppet_role/zookeeper.yaml
+++ b/hieradata/puppet_role/zookeeper.yaml
@@ -1,5 +1,5 @@
 ---
-
+zookeeper::exhibitor_version: "1.7.1-1"
 profile::zookeeper::zookeeper_nodes: "%{::zookeeper_nodes}"
 zookeeper::backup_enable: true
 zookeeper::backup_bucket_name: "%{::backup_bucket}"
@@ -9,3 +9,5 @@ zookeeper::zookeeper_java_env: "SERVER_JVMFLAGS=-javaagent:/opt/jmx_exporter-%{h
 cloudwatchlog_files:
   "/talend/tic/%{::main_stack}/%{::puppet_role}/opt/tomcat/logs/catalina.out":
     path: '/opt/apache-tomcat/logs/catalina.out'
+  "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/zookeeper/zookeeper.log":
+    path: '/var/log/zookeeper/zookeeper.log*'

--- a/spec/acceptance/shared/zookeeper.rb
+++ b/spec/acceptance/shared/zookeeper.rb
@@ -6,6 +6,10 @@ shared_examples 'profile::zookeeper' do
     /opt/apache-tomcat/logs/catalina.out
   )
 
+  describe command('/usr/bin/sleep 120') do
+    its(:exit_status) { should eq 0 }
+  end
+
   describe port(2181) do
     it { should be_listening }
   end

--- a/spec/acceptance/shared/zookeeper.rb
+++ b/spec/acceptance/shared/zookeeper.rb
@@ -4,6 +4,7 @@ shared_examples 'profile::zookeeper' do
   it_behaves_like 'profile::common::packagecloud_repos'
   it_behaves_like 'profile::common::cloudwatchlog_files', %w(
     /opt/apache-tomcat/logs/catalina.out
+    /var/log/zookeeper/zookeeper.log
   )
 
   describe command('/usr/bin/sleep 120') do
@@ -20,6 +21,11 @@ shared_examples 'profile::zookeeper' do
 
   describe package('jre-jce') do
     it { should_not be_installed }
+  end
+
+  describe 'Exhibitor package' do
+    subject { command('/bin/rpm -q netflix-exhibitor-tomcat') }
+    its(:stdout) { should include 'netflix-exhibitor-tomcat-1.7.1-1.x86_64' }
   end
 
   describe file('/etc/rc.d/init.d/zookeeper') do
@@ -49,5 +55,4 @@ shared_examples 'profile::zookeeper' do
   describe command('echo ruok | /bin/nc 127.0.0.1 2181') do
     its(:stdout) { should eq 'imok' }
   end
-
 end


### PR DESCRIPTION
tested with:
``` bash
λ ./scripts/local_dev_tests.sh -t role-zookeeper-centos-76
...
role::zookeeper
  behaves like profile::base
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "base"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatchlogs
      behaves like profile::common::cloudwatchlog_files
        Service "awslogs"
          configuration [/etc/awslogs/awslogs.conf]
            should include "file = /var/log/audit/audit.log"
            should include "file = /var/log/messages"
            should include "file = /var/log/secure"
      Service "awslogs"
        should be enabled
        should be running
    behaves like profile::common::ssm
      Package "amazon-ssm-agent"
        should be installed
    behaves like monitoring::node_exporter
      User "node_exporter"
        should exist
      Service "node_exporter.service"
        should be enabled
        should be running
      Command "/usr/bin/curl -v http://127.0.0.1:9100/metrics"
        exit_status
          should eq 0
        stdout
          should include "node_filesystem_size"
    ntp configuration
      should include "restrict default nomodify notrap nopeer noquery"
      should include "server 0.amazon.pool.ntp.org iburst"
      should include "server 1.amazon.pool.ntp.org iburst"
      should include "server 2.amazon.pool.ntp.org iburst"
      should include "server 3.amazon.pool.ntp.org iburst"
    logrotate for syslog configuration
      should include "rotate 8"
      should include "daily"
      should include "compress"
      should include "delaycompress"
    ntp sync
      should include "synchronised to"
      should include "time correct to within"
  behaves like profile::zookeeper
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "zookeeper"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::cloudwatchlog_files
      Service "awslogs"
        configuration [/etc/awslogs/awslogs.conf]
          should include "file = /opt/apache-tomcat/logs/catalina.out"
          should include "file = /var/log/zookeeper/zookeeper.log"
    Command "/usr/bin/sleep 120"
      exit_status
        should eq 0
    Port "2181"
      should be listening
    Command "/usr/bin/curl http://127.0.0.1:8080/exhibitor/v1/cluster/state"
      stdout
        should match /"description":".*?"/
    Package "jre-jce"
      should not be installed
    Exhibitor package
      stdout
        should include "netflix-exhibitor-tomcat-1.7.1-1.x86_64"
    File "/etc/rc.d/init.d/zookeeper"
      should not exist
    File "/home/tomcat"
      should be directory
      should be owned by "tomcat"
    File "/etc/init.d/zookeeper"
      should not exist
    Service "tomcat-exhibitor"
      should be running under systemd
    Command "/usr/bin/curl -v http://127.0.0.1:8080/exhibitor/v1/config/get-state"
      stdout
        should include "\"clientPort\":2181"
      stdout
        should include "\"connectPort\":2888"
      stdout
        should include "\"electionPort\":3888"
    Command "echo ruok | /bin/nc 127.0.0.1 2181"
      stdout
        should eq "imok"
  behaves like role::defined
    File "/etc/sysconfig/puppetRole"
      should be file
      content
        should include "zookeeper"

Finished in 2 minutes 7 seconds (files took 0.26331 seconds to load)
57 examples, 0 failures

       Finished verifying <role-zookeeper-centos-76> (2m7.61s).
-----> Destroying <role-zookeeper-centos-76>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-zookeeper-centos-76> destroyed.
       Finished destroying <role-zookeeper-centos-76> (0m3.23s).
       Finished testing <role-zookeeper-centos-76> (15m46.93s).
```