### PR TITLE
Update postgresql libraries for activemq and tests

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -108,7 +108,7 @@ GIT
 GITHUBTARBALL
   remote: Talend/puppet-activemq
   specs:
-    talend-activemq (0.4.3)
+    talend-activemq (0.4.4)
 
 GITHUBTARBALL
   remote: Talend/puppet-cloudwatchlogs

--- a/site/profile/manifests/postgresql/install.pp
+++ b/site/profile/manifests/postgresql/install.pp
@@ -1,9 +1,9 @@
 class profile::postgresql::install {
 
   class { 'postgresql::globals':
-    version             => '9.5',
+    version             => '11',
     encoding            => 'UTF8',
-    locale              => 'en_NG',
+    locale              => 'en_US.UTF8',
     manage_package_repo => true,
   }
 

--- a/spec/acceptance/shared/activemq.rb
+++ b/spec/acceptance/shared/activemq.rb
@@ -21,6 +21,10 @@ shared_examples 'profile::activemq' do
     it { should_not be_installed }
   end
 
+  describe package('postgresql11') do
+    it { should be_installed }
+  end
+
   describe file('/opt/activemq/conf/activemq.xml') do
     its(:content) { should include '<queue physicalName="ipaas.talend.dispatcher.response.queue"/>' }
   end


### PR DESCRIPTION
local test:
```
role::activemq
  behaves like profile::base
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "base"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatchlogs
      behaves like profile::common::cloudwatchlog_files
        Service "awslogs"
          configuration [/etc/awslogs/awslogs.conf]
            should include "file = /var/log/audit/audit.log"
            should include "file = /var/log/messages"
            should include "file = /var/log/secure"
      Service "awslogs"
        should be enabled
        should be running
    behaves like profile::common::ssm
      Package "amazon-ssm-agent"
        should be installed
    behaves like monitoring::node_exporter
      User "node_exporter"
        should exist
      Service "node_exporter.service"
        should be enabled
        should be running
      Command "/usr/bin/curl -v http://127.0.0.1:9100/metrics"
        exit_status
          should eq 0
        stdout
          should include "node_filesystem_size"
    ntp configuration
      should include "restrict default nomodify notrap nopeer noquery"
      should include "server 0.amazon.pool.ntp.org iburst"
      should include "server 1.amazon.pool.ntp.org iburst"
      should include "server 2.amazon.pool.ntp.org iburst"
      should include "server 3.amazon.pool.ntp.org iburst"
    logrotate for syslog file properties
      should be owned by "root"
      should be grouped into "root"
      should be mode 644
    logrotate for syslog configuration
      should include "rotate 8"
      should include "daily"
      should include "compress"
      should include "delaycompress"
    ntp sync
      should include "synchronised to"
      should include "time correct to within"
  behaves like profile::activemq
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "activemq"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::cloudwatchlog_files
      Service "awslogs"
        configuration [/etc/awslogs/awslogs.conf]
          should include "file = /opt/activemq/data/activemq.log"
    Service "activemq"
      should be enabled
      should be running
    Port "8161"
      should be listening
    Port "5432"
      should be listening
    Package "jre-jce"
      should not be installed
    Package "postgresql11"
      should be installed
    File "/opt/activemq/conf/activemq.xml"
      content
        should include "<queue physicalName=\"ipaas.talend.dispatcher.response.queue\"/>"
    ActiveMQ optimization version table
      stdout
        should include "0.1"
    get ActiveMQ optimizations from activemq_msgs
      exit_status
        should eq 0
    get ActiveMQ optimizations from activemq_acks
      exit_status
        should eq 0
    verifying ActiveMQ optimizations for activemq_msgs
      content
        should include "tmp_activemq_msgs_p_desc_idx"
      content
        should include "tmp_activemq_msgs_pc_asc_idx"
      content
        should include "tmp_activemq_msgs_pcx_asc_idx"
      content
        should include "tmp_activemq_msgs_pcp_idx"
      content
        should include "tmp_activemq_msgs_pxpc_asc_desc_idx"
      content
        should include "autovacuum_vacuum_cost_limit=2000"
      content
        should include "autovacuum_vacuum_cost_delay=10"
      content
        should include "autovacuum_vacuum_scale_factor=0"
      content
        should include "autovacuum_vacuum_threshold=5000"
      content
        should include "autovacuum_analyze_threshold=1000"
      content
        should include "autovacuum_analyze_scale_factor=0.01"
    verifying ActiveMQ optimizations for activemq_acks
      content
        should include "tmp_activemq_acks_c_idx"
  behaves like role::defined
    File "/etc/sysconfig/puppetRole"
      should be file
      content
        should include "activemq"
  Package "jre1.8"
    should be installed with version "1.8.0_181-fcs"

Finished in 9.33 seconds (files took 0.36525 seconds to load)
68 examples, 0 failures

       Finished verifying <role-activemq-centos-76> (0m10.08s).
-----> Destroying <role-activemq-centos-76>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-activemq-centos-76> destroyed.
       Finished destroying <role-activemq-centos-76> (0m4.95s).
       Finished testing <role-activemq-centos-76> (21m30.07s).
-----> Kitchen is finished. (21m30.40s)
```