### PR TITLE
TMC-18392: Add export GC logs for frontend and Bump Puppet-tic

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -138,7 +138,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: Talend/puppet-tic
   specs:
-    talend-tic (0.2.9.44)
+    talend-tic (0.2.9.45)
 
 GITHUBTARBALL
   remote: Talend/puppet-user_accounts

--- a/hieradata/puppet_role/frontend.yaml
+++ b/hieradata/puppet_role/frontend.yaml
@@ -94,6 +94,9 @@ cloudwatchlog_files:
   "/talend/tic/%{::main_stack}/%{::puppet_role}/srv/tomcat/ipaas-srv/logs/ipaas.log":
     path: '/srv/tomcat/ipaas-srv/logs/ipaas.log'
     datetime_format: '%Y-%m-%d %H:%M:%S,%f'
+  "/talend/tic/%{::main_stack}/%{::puppet_role}/srv/tomcat/ipaas-srv/logs/gc.log":
+    path: '/srv/tomcat/ipaas-srv/logs/gc.log'
+    datetime_format: '%Y-%m-%d %H:%M:%S,%f'
 
 nginx::config::server_tokens: 'off'
 nginx::config::keepalive_timeout: '5 5'


### PR DESCRIPTION
Adding GC logs export to follow recuring issue with gc overrhead on prod EU.