### PR TITLE
fix rake version to latest compatible with Centos 7 ruby

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -5,6 +5,9 @@ sudo::purge: false
 nginx::package_ensure: '1.12.1-1.el7.ngx'
 
 common_packages:
+  'rake':
+    ensure: '12.3.3'
+    provider: 'gem'
   'hiera-eyaml':
     ensure: 'installed'
     provider: 'gem'


### PR DESCRIPTION
tested locally:
```bash
λ ./scripts/local_dev_tests.sh -t role-activemq-centos-76
....
....
Finished in 5.32 seconds (files took 0.24911 seconds to load)
68 examples, 0 failures

       Finished verifying <role-activemq-centos-76> (0m5.84s).
-----> Destroying <role-activemq-centos-76>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-activemq-centos-76> destroyed.
       Finished destroying <role-activemq-centos-76> (0m2.99s).
       Finished testing <role-activemq-centos-76> (20m25.69s).
```