### PR TITLE
update-bento-centos-77

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,7 +40,7 @@ transport:
   name: sftp
 
 platforms:
-  - name: centos-7.6
+  - name: centos-7.7
 
 verifier:
   name: serverspec


### PR DESCRIPTION
Updating to new Bento CentOS image to have local/vagrant test to the same level than current AMI builds (CentOS 7.7).
tested with `./scripts/local_dev_tests.sh -t role-base-centos-77`