### PR TITLE
fix(DEVOPS-8075): set localhost as ip

### DIFF
--- a/site/profile/manifests/nginx_amq_reverseproxy.pp
+++ b/site/profile/manifests/nginx_amq_reverseproxy.pp
@@ -20,7 +20,7 @@ class profile::nginx_amq_reverseproxy (
     keepalive_timeout       => 65,
     proxy_buffers           => undef,
     proxy_buffer_size       => undef,
-    proxy_connect_timeout   => '10s',
+    proxy_connect_timeout   => '60s',
     proxy_read_timeout      => '60s',
     proxy_redirect          => 'off',
     proxy_send_timeout      => '35s',
@@ -33,7 +33,7 @@ class profile::nginx_amq_reverseproxy (
 
   nginx::resource::vhost { 'jetty':
     listen_port    => 80,
-    proxy          => 'http://localhost:8080',
+    proxy          => 'http://127.0.0.1:8080',
     server_name    => ['_'],
     listen_options => 'default_server',
     index_files    => [],


### PR DESCRIPTION
The communication from Nginx to local ActiveMQ tries to use IPv6 because of localhost resolution.
We have noticed a lot of up/down on Pingdom.

Error raised on nginx logs
```
2019/11/12 23:28:37 [error] 12669#12669: *303 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 10.72.0.99, server: _, request: "POST / HTTP/1.1", upstream: "http://[::1]:8080/", host: "msg.at.cloud.talend.com"
```


Replace by 127.0.0.1 solves the issue.
Also increase the connection time to 60s, as its default value.