### PR TITLE
Update ecs agent to 1.34.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -342,6 +342,7 @@ suites:
   - name: role-ecs
     driver:
       vagrantfiles:
+        - vagrant/2cpu-2gb.rb
         - vagrant/second_disk.rb
       vm_name: ecs-tci
       customize:
@@ -356,6 +357,7 @@ suites:
   - name: ami-ecs
     driver:
       vagrantfiles:
+        - vagrant/2cpu-2gb.rb
         - vagrant/second_disk.rb
       vm_name: ami-ecs-tci
       customize:

--- a/hieradata/puppet_role/ecs.yaml
+++ b/hieradata/puppet_role/ecs.yaml
@@ -9,7 +9,7 @@ profile::docker::host::storage_device: "%{::storage_device}"
 
 profile::docker::ecs_agent::running: true
 profile::docker::ecs_agent::cluster_name: "%{::cluster_name}"
-profile::docker::ecs_agent::image: 'amazon/amazon-ecs-agent:v1.32.0'
+profile::docker::ecs_agent::image: 'amazon/amazon-ecs-agent:v1.34.0'
 
 profile::datadog_docker_agent::image: 'datadog/docker-dd-agent:12.6.5223'
 

--- a/site/profile/manifests/docker/ecs_agent.pp
+++ b/site/profile/manifests/docker/ecs_agent.pp
@@ -5,7 +5,7 @@ class profile::docker::ecs_agent (
 
   $cluster_name = undef,
   $running      = true,
-  $image        = 'amazon/amazon-ecs-agent:v1.32.0',
+  $image        = 'amazon/amazon-ecs-agent:v1.34.0',
 
 ) {
 


### PR DESCRIPTION
https://github.com/aws/amazon-ecs-agent/releases/tag/v1.34.0

```
Finished in 17.42 seconds (files took 0.37879 seconds to load)
69 examples, 0 failures

       Finished verifying <role-ecs-centos-77> (0m18.22s).
-----> Destroying <role-ecs-centos-77>...
       /home/eseite/dev/Talend/talend-cloud-installer/vagrant/second_disk.rb:1: warning: already initialized constant VAGRANTFILE_API_VERSION
       /home/eseite/dev/Talend/talend-cloud-installer/vagrant/2cpu-2gb.rb:1: warning: previous definition of VAGRANTFILE_API_VERSION was here
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-ecs-centos-77> destroyed.
       Finished destroying <role-ecs-centos-77> (0m3.30s).
       Finished testing <role-ecs-centos-77> (19m29.12s).
-----> Kitchen is finished. (19m29.45s)
```