### PR TITLE
DEVOPS-8513: ActiveMQ patched + new monitoring

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -49,5 +49,5 @@ mod 'puppetlabs-postgresql',
   :ref => 'master'
 mod 'puppetlabs-mongodb', '0.18.1',
   :github_tarball => 'Talend/puppet-mongodb'
-mod 'talend-monitoring', '0.1.0.22',
+mod 'talend-monitoring', '0.2.0',
   :github_tarball => 'Talend/puppet-monitoring'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -128,7 +128,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: Talend/puppet-monitoring
   specs:
-    talend-monitoring (0.1.0.22)
+    talend-monitoring (0.2.0)
 
 GITHUBTARBALL
   remote: Talend/puppet-syncope
@@ -178,7 +178,7 @@ DEPENDENCIES
   talend-cloudwatchlogs (~> 0.0)
   talend-dataprep_dataset (~> 0.0)
   talend-kafka (>= 0)
-  talend-monitoring (= 0.1.0.22)
+  talend-monitoring (= 0.2.0)
   talend-syncope (~> 0.0)
   talend-tic (~> 0.0)
   talend-user_accounts (~> 0.0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -96,6 +96,6 @@ monitoring::cadvisor::port: 9500
 monitoring::mongodb_exporter::version: '0.3.1'
 monitoring::mongodb_exporter::port: 9216
 
-monitoring::jmx_exporter::version: '0.3.1'
+monitoring::jmx_exporter::version: '0.12.0'
 monitoring::jmx_exporter::user: 'root'
 jmx_exporter_port: 9404

--- a/hieradata/puppet_role/activemq.yaml
+++ b/hieradata/puppet_role/activemq.yaml
@@ -8,7 +8,7 @@ common_packages:
   'ptic-postgresql-schemes':
     ensure: '2.0-4'
 
-activemq::version: '5.15.11-2'
+activemq::version: '5.15.11-3'
 activemq::tcp_max_frame_size: 104857600  # 100MiB
 activemq::http_max_frame_size: 52428800  # 50MiB
 activemq::jmx_enabled: true

--- a/spec/acceptance/shared/activemq.rb
+++ b/spec/acceptance/shared/activemq.rb
@@ -5,7 +5,7 @@ shared_examples 'profile::activemq' do
   it_behaves_like 'profile::common::cloudwatchlog_files', %w(/opt/activemq/data/activemq.log)
 
   describe package('activemq') do
-    it { should be_installed.with_version('5.15.11-2') }
+    it { should be_installed.with_version('5.15.11-3') }
   end
 
 	describe service('activemq') do


### PR DESCRIPTION
```
role::activemq
  behaves like profile::base
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "base"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatchlogs
      behaves like profile::common::cloudwatchlog_files
        Service "awslogs"
          configuration [/etc/awslogs/awslogs.conf]
            should include "file = /var/log/audit/audit.log"
            should include "file = /var/log/messages"
            should include "file = /var/log/secure"
      Service "awslogs"
        should be enabled
        should be running
    behaves like profile::common::ssm
      Package "amazon-ssm-agent"
        should be installed
    behaves like monitoring::node_exporter
      User "node_exporter"
        should exist
      Service "node_exporter.service"
        should be enabled
        should be running
      Command "/usr/bin/curl -v http://127.0.0.1:9100/metrics"
        exit_status
          should eq 0
        stdout
          should include "node_filesystem_size"
    ntp configuration
      should include "restrict default nomodify notrap nopeer noquery"
      should include "server 0.amazon.pool.ntp.org iburst"
      should include "server 1.amazon.pool.ntp.org iburst"
      should include "server 2.amazon.pool.ntp.org iburst"
      should include "server 3.amazon.pool.ntp.org iburst"
    logrotate for syslog file properties
      should be owned by "root"
      should be grouped into "root"
      should be mode 644
    logrotate for syslog configuration
      should include "rotate 8"
      should include "daily"
      should include "compress"
      should include "delaycompress"
    ntp sync
      should include "synchronised to"
      should include "time correct to within"
  behaves like profile::activemq
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "activemq"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::cloudwatchlog_files
      Service "awslogs"
        configuration [/etc/awslogs/awslogs.conf]
          should include "file = /opt/activemq/data/activemq.log"
    Package "activemq"
      should be installed with version "5.15.11-3"
    Service "activemq"
      should be enabled
      should be running
    Port "8161"
      should be listening
    Port "5432"
      should be listening
    Package "jre-jce"
      should not be installed
    Package "postgresql11"
      should be installed
    File "/opt/activemq/conf/activemq.xml"
      content
        should include "<queue physicalName=\"ipaas.talend.dispatcher.response.queue\"/>"
      content
        should include "tcp://0.0.0.0:61616?maximumConnections=5000&amp;wireFormat.maxFrameSize=104857600"
      content
        should include "http://0.0.0.0:8080?jetty.config=/opt/activemq/conf/jetty-server.xml&amp;wireFormat.maxFrameSize=52428800"
    File "/opt/activemq/conf/jetty-server.xml"
      content
        should include "<Set name=\"minThreads\">10</Set>"
      content
        should include "<Set name=\"maxThreads\">3000</Set>"
    ActiveMQ optimization version table
      stdout
        should include "0.1"
    get ActiveMQ optimizations from activemq_msgs
      exit_status
        should eq 0
    get ActiveMQ optimizations from activemq_acks
      exit_status
        should eq 0
    verifying ActiveMQ optimizations for activemq_msgs
      content
        should include "tmp_activemq_msgs_p_desc_idx"
      content
        should include "tmp_activemq_msgs_pc_asc_idx"
      content
        should include "tmp_activemq_msgs_pcx_asc_idx"
      content
        should include "tmp_activemq_msgs_pcp_idx"
      content
        should include "tmp_activemq_msgs_pxpc_asc_desc_idx"
      content
        should include "autovacuum_vacuum_cost_limit=2000"
      content
        should include "autovacuum_vacuum_cost_delay=10"
      content
        should include "autovacuum_vacuum_scale_factor=0"
      content
        should include "autovacuum_vacuum_threshold=5000"
      content
        should include "autovacuum_analyze_threshold=1000"
      content
        should include "autovacuum_analyze_scale_factor=0.01"
    verifying ActiveMQ optimizations for activemq_acks
      content
        should include "tmp_activemq_acks_c_idx"
  behaves like role::defined
    File "/etc/sysconfig/puppetRole"
      should be file
      content
        should include "activemq"
  Package "jre1.8"
    should be installed with version "1.8.0_181-fcs"

Finished in 8.05 seconds (files took 0.26567 seconds to load)
73 examples, 0 failures

       Finished verifying <role-activemq-centos-77> (0m8.65s).
-----> Destroying <role-activemq-centos-77>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-activemq-centos-77> destroyed.
       Finished destroying <role-activemq-centos-77> (0m3.27s).
       Finished testing <role-activemq-centos-77> (22m21.32s).
```