### PR TITLE
DEVOPS-8284 enlarge topics msg size

### DIFF
--- a/hieradata/puppet_role/kafka.yaml
+++ b/hieradata/puppet_role/kafka.yaml
@@ -85,8 +85,10 @@ kafka_customers_logs_cluster_ha: # estimated max cluster size: 308 GiB + custome
     tmc_logs:
       partitions: "30"
       topic_options:
-        retention.ms: "43200000"      # 12h
-        retention.bytes: "3586297696" # 3.34GiB per partition
+        retention.ms: "43200000"        # 12h
+        retention.bytes: "3586297696"   # 3.34GiB per partition
+        max.message.bytes: "104857600"  # 100 MiB, align with ActiveMQ max message size
+        segment.ms: "300000"            # 5mn
 
 kafka_applications_cluster_ha: # estimated max cluster size: 96 GiB (24 topics with default -3 GiB-  + 3 with custom size) + customers offsets  => 55 GiB per node with security
   kafka_topics_default_partitions: 12


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/DEVOPS-8284

- Following the #306, enlarge message size to 100MiB on Kafka topic `tmc_logs`.
(default was 1MiB)
- Set *segment.ms* to 5 minutes.

To be exhaustive, incoming message limitation is also defined on ActiveMQ config :
https://github.com/Talend/talend-cloud-installer/blob/master/hieradata/puppet_role/activemq.yaml#L12