### PR TITLE
DEVOPS-8569: Tuning Jetty for ActiveMQ

### DIFF
--- a/site/profile/files/etc/sysctl.d/activemq_jetty.conf
+++ b/site/profile/files/etc/sysctl.d/activemq_jetty.conf
@@ -1,0 +1,12 @@
+# File managed by Puppet, do not edit manually
+# https://www.eclipse.org/jetty/documentation/current/high-load.html
+net.core.rmem_max=16777216
+net.core.wmem_max=16777216
+net.ipv4.tcp_rmem=4096 87380 16777216
+net.ipv4.tcp_wmem=4096 16384 16777216
+net.core.somaxconn=4096
+net.core.netdev_max_backlog=16384
+net.ipv4.tcp_max_syn_backlog=8192
+net.ipv4.tcp_syncookies=1
+net.ipv4.ip_local_port_range=10000 65535
+net.ipv4.tcp_tw_recycle=1

--- a/site/profile/manifests/activemq.pp
+++ b/site/profile/manifests/activemq.pp
@@ -18,6 +18,23 @@ class profile::activemq(
 
   profile::register_profile { 'activemq': }
 
+  file { 'activemq sysctl conf':
+    ensure => file,
+    path   => '/etc/sysctl.d/activemq_jetty.conf',
+    source => 'puppet:///modules/profile/etc/sysctl.d/activemq_jetty.conf',
+    mode   => '0644',
+    owner  => 'root',
+    group  => 'root',
+    before => Class['::activemq'],
+    notify => Exec['activemq sysctl apply']
+  }
+
+  exec { 'activemq sysctl apply':
+    path        => '/usr/bin:/usr/sbin/:/bin:/sbin',
+    command     => 'sysctl --system',
+    refreshonly => true
+  }
+
   # prevent postgres provisioning on all the nodes except one: ActiveMQ-A
   # this should be replaced with more sophisticated solution in the future
   $ec2_userdata = pick_default($::ec2_userdata, '')
@@ -43,7 +60,6 @@ class profile::activemq(
         }
       }
     }
-
   } else {
     contain ::activemq
   }

--- a/spec/acceptance/shared/activemq.rb
+++ b/spec/acceptance/shared/activemq.rb
@@ -4,6 +4,25 @@ shared_examples 'profile::activemq' do
   it_behaves_like 'profile::common::packagecloud_repos'
   it_behaves_like 'profile::common::cloudwatchlog_files', %w(/opt/activemq/data/activemq.log)
 
+  describe 'Verifying activemq sysctl conf' do
+    describe file('/etc/sysctl.d/activemq_jetty.conf') do
+      it { should be_file }
+      its(:content) { should include '# File managed by Puppet, do not edit manually' }
+    end
+    describe command('/sbin/sysctl -a') do
+      its(:stdout) { should include 'net.core.rmem_max = 16777216' }
+      its(:stdout) { should include 'net.core.wmem_max = 16777216' }
+      its(:stdout) { should include 'net.ipv4.tcp_rmem = 4096	87380	16777216' }
+      its(:stdout) { should include 'net.ipv4.tcp_wmem = 4096	16384	16777216' }
+      its(:stdout) { should include 'net.core.somaxconn = 4096' }
+      its(:stdout) { should include 'net.core.netdev_max_backlog = 16384' }
+      its(:stdout) { should include 'net.ipv4.tcp_max_syn_backlog = 8192' }
+      its(:stdout) { should include 'net.ipv4.tcp_syncookies = 1' }
+      its(:stdout) { should include 'net.ipv4.ip_local_port_range = 10000	65535' }
+      its(:stdout) { should include 'net.ipv4.tcp_tw_recycle = 1' }
+    end
+  end
+
   describe package('activemq') do
     it { should be_installed.with_version('5.15.11-3') }
   end


### PR DESCRIPTION
Kernel tuning for ActiveMQ and being able to handle 3000 connections and more:
```
role::activemq
  behaves like profile::base
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "base"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::packages
      Package "cloud-init"
        should be installed
      Package "hiera-eyaml"
        should be installed by "gem"
      Package "hiera-eyaml-kms"
        should be installed by "gem"
      Package "aws-sdk"
        should be installed by "gem"
      Package "package_cloud"
        should be installed by "gem"
    behaves like profile::common::cloudwatchlogs
      behaves like profile::common::cloudwatchlog_files
        Service "awslogs"
          configuration [/etc/awslogs/awslogs.conf]
            should include "file = /var/log/audit/audit.log"
            should include "file = /var/log/messages"
            should include "file = /var/log/secure"
      Service "awslogs"
        should be enabled
        should be running
    behaves like profile::common::ssm
      Package "amazon-ssm-agent"
        should be installed
    behaves like monitoring::node_exporter
      User "node_exporter"
        should exist
      Service "node_exporter.service"
        should be enabled
        should be running
      Command "/usr/bin/curl -v http://127.0.0.1:9100/metrics"
        exit_status
          should eq 0
        stdout
          should include "node_filesystem_size"
    ntp configuration
      should include "restrict default nomodify notrap nopeer noquery"
      should include "server 0.amazon.pool.ntp.org iburst"
      should include "server 1.amazon.pool.ntp.org iburst"
      should include "server 2.amazon.pool.ntp.org iburst"
      should include "server 3.amazon.pool.ntp.org iburst"
    logrotate for syslog file properties
      should be owned by "root"
      should be grouped into "root"
      should be mode 644
    logrotate for syslog configuration
      should include "rotate 8"
      should include "daily"
      should include "compress"
      should include "delaycompress"
    ntp sync
      should include "synchronised to"
      should include "time correct to within"
  behaves like profile::activemq
    behaves like profile::defined
      File "/etc/sysconfig/puppetProfile"
        should be file
        content
          should include "activemq"
    behaves like profile::common::packagecloud_repos
      Yumrepo "talend_other"
        should exist
        should be enabled
      Yumrepo "talend_thirdparty"
        should exist
        should be enabled
    behaves like profile::common::cloudwatchlog_files
      Service "awslogs"
        configuration [/etc/awslogs/awslogs.conf]
          should include "file = /opt/activemq/data/activemq.log"
    Verifying activemq sysctl conf
      File "/etc/sysctl.d/activemq_jetty.conf"
        should be file
        content
          should include "# File managed by Puppet, do not edit manually"
      Command "/sbin/sysctl -a"
        stdout
          should include "net.core.rmem_max = 16777216"
        stdout
          should include "net.core.wmem_max = 16777216"
        stdout
          should include "net.ipv4.tcp_rmem = 4096\t87380\t16777216"
        stdout
          should include "net.ipv4.tcp_wmem = 4096\t16384\t16777216"
        stdout
          should include "net.core.somaxconn = 4096"
        stdout
          should include "net.core.netdev_max_backlog = 16384"
        stdout
          should include "net.ipv4.tcp_max_syn_backlog = 8192"
        stdout
          should include "net.ipv4.tcp_syncookies = 1"
        stdout
          should include "net.ipv4.ip_local_port_range = 10000\t65535"
        stdout
          should include "net.ipv4.tcp_tw_recycle = 1"
    Package "activemq"
      should be installed with version "5.15.11-3"
    Service "activemq"
      should be enabled
      should be running
    Port "8161"
      should be listening
    Port "5432"
      should be listening
    Package "jre-jce"
      should not be installed
    Package "postgresql11"
      should be installed
    File "/opt/activemq/conf/activemq.xml"
      content
        should include "<queue physicalName=\"ipaas.talend.dispatcher.response.queue\"/>"
      content
        should include "tcp://0.0.0.0:61616?maximumConnections=5000&amp;wireFormat.maxFrameSize=104857600"
      content
        should include "http://0.0.0.0:8080?jetty.config=/opt/activemq/conf/jetty-server.xml&amp;wireFormat.maxFrameSize=52428800"
    File "/opt/activemq/conf/jetty-server.xml"
      content
        should include "<Set name=\"minThreads\">10</Set>"
      content
        should include "<Set name=\"maxThreads\">3000</Set>"
    ActiveMQ optimization version table
      stdout
        should include "0.1"
    get ActiveMQ optimizations from activemq_msgs
      exit_status
        should eq 0
    get ActiveMQ optimizations from activemq_acks
      exit_status
        should eq 0
    verifying ActiveMQ optimizations for activemq_msgs
      content
        should include "tmp_activemq_msgs_p_desc_idx"
      content
        should include "tmp_activemq_msgs_pc_asc_idx"
      content
        should include "tmp_activemq_msgs_pcx_asc_idx"
      content
        should include "tmp_activemq_msgs_pcp_idx"
      content
        should include "tmp_activemq_msgs_pxpc_asc_desc_idx"
      content
        should include "autovacuum_vacuum_cost_limit=2000"
      content
        should include "autovacuum_vacuum_cost_delay=10"
      content
        should include "autovacuum_vacuum_scale_factor=0"
      content
        should include "autovacuum_vacuum_threshold=5000"
      content
        should include "autovacuum_analyze_threshold=1000"
      content
        should include "autovacuum_analyze_scale_factor=0.01"
    verifying ActiveMQ optimizations for activemq_acks
      content
        should include "tmp_activemq_acks_c_idx"
  behaves like role::defined
    File "/etc/sysconfig/puppetRole"
      should be file
      content
        should include "activemq"
  Package "jre1.8"
    should be installed with version "1.8.0_181-fcs"

Finished in 8.41 seconds (files took 0.34866 seconds to load)
85 examples, 0 failures

       Finished verifying <role-activemq-centos-77> (0m9.20s).
-----> Destroying <role-activemq-centos-77>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <role-activemq-centos-77> destroyed.
       Finished destroying <role-activemq-centos-77> (0m3.42s).
       Finished testing <role-activemq-centos-77> (26m48.25s).
-----> Kitchen is finished. (26m48.49s)
```
