### PR TITLE
TPSVC-12971 - MongoShare Add Admin role (AWS)

### DIFF
--- a/hieradata/puppet_role/mongodb.yaml
+++ b/hieradata/puppet_role/mongodb.yaml
@@ -39,6 +39,17 @@ profile::mongodb::roles:
     roles: []
 
 profile::mongodb::users:
+  admin:
+    db_address: 'admin'
+    username: 'admin'
+    password: '%{::master_password}'
+    roles:
+      - role: 'userAdminAnyDatabase'
+        db: 'admin'
+      - role: 'dbAdminAnyDatabase'
+        db: 'admin'
+      - role: 'readWriteAnyDatabase'
+        db: 'admin'
   backup:
     db_address: 'admin'
     username: 'backup'


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
[EK migration scope] tpsvc config service need to be able to create the tpsvc_config mongo user (EKS initDB sidecar container)
Currently there is no admin user available to do that
**What is the chosen solution to this problem?**
Add the admin user 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-12971

**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->

**[ ] This Pull Request introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
