### PR TITLE
feat(DEVOPS-6356): remove MongoDB exporter

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -2,77 +2,77 @@
 message: "This node is using common data"
 sudo::purge: false
 
-nginx::package_ensure: '1.12.1-1.el7.ngx'
+nginx::package_ensure: "1.12.1-1.el7.ngx"
 
 common_packages:
-  'rake':
-    ensure: '12.3.3'
-    provider: 'gem'
-  'hiera-eyaml':
-    ensure: 'installed'
-    provider: 'gem'
-  'hiera-eyaml-kms':
-    ensure: 'installed'
-    provider: 'gem'
-  'aws-sdk':
-    ensure: 'installed'
-    provider: 'gem'
-  'package_cloud':
-    ensure: '0.2.45'
-    provider: 'gem'
-  'nmap-ncat':
-    ensure: 'installed'
-  'cloud-init':
-    ensure: 'installed'
-  'awscli':
-    ensure: 'installed'
-    provider: 'pip'
-  'lnav':
-    ensure: 'installed'
-  'python-virtualenv':
-    ensure: 'absent'
+  "rake":
+    ensure: "12.3.3"
+    provider: "gem"
+  "hiera-eyaml":
+    ensure: "installed"
+    provider: "gem"
+  "hiera-eyaml-kms":
+    ensure: "installed"
+    provider: "gem"
+  "aws-sdk":
+    ensure: "installed"
+    provider: "gem"
+  "package_cloud":
+    ensure: "0.2.45"
+    provider: "gem"
+  "nmap-ncat":
+    ensure: "installed"
+  "cloud-init":
+    ensure: "installed"
+  "awscli":
+    ensure: "installed"
+    provider: "pip"
+  "lnav":
+    ensure: "installed"
+  "python-virtualenv":
+    ensure: "absent"
 
 packagecloud_repos:
-  'talend/other':
-    type: 'rpm'
+  "talend/other":
+    type: "rpm"
     master_token: "%{::packagecloud_master_token}"
-  'talend/thirdparty':
-    type: 'rpm'
+  "talend/thirdparty":
+    type: "rpm"
 
 cloudwatchlogs::region: "%{::region}"
 profile::common::ssm::region: "%{::region}"
 
 cloudwatchlog_files:
   "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/cfn-init.log":
-    path: '/var/log/cfn-init.log'
+    path: "/var/log/cfn-init.log"
   "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/cfn-init-cmd.log":
-    path: '/var/log/cfn-init-cmd.log'
+    path: "/var/log/cfn-init-cmd.log"
   "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/messages":
-    path: '/var/log/messages'
+    path: "/var/log/messages"
   "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/secure":
-    path: '/var/log/secure'
+    path: "/var/log/secure"
   "/talend/tic/%{::main_stack}/%{::puppet_role}/var/log/audit/audit.log":
-    path: '/var/log/audit/audit.log'
-    datetime_format: '%s'
+    path: "/var/log/audit/audit.log"
+    datetime_format: "%s"
 
-profile::web::tomcat::catalina_base: '/opt/apache-tomcat/tomcat'
-profile::web::tomcat::tomcat_version: '8'
+profile::web::tomcat::catalina_base: "/opt/apache-tomcat/tomcat"
+profile::web::tomcat::tomcat_version: "8"
 
 ntp::udlc: true
 ntp::interfaces:
-  - '127.0.0.1'
-  - '::1'
+  - "127.0.0.1"
+  - "::1"
   - "%{::ipaddress_eth0}"
 ntp::restrict:
-  - 'default nomodify notrap nopeer noquery'
-  - '127.0.0.1'
-  - '::1'
-  - '10.200.0.0 mask 255.255.0.0 nomodify notrap'
+  - "default nomodify notrap nopeer noquery"
+  - "127.0.0.1"
+  - "::1"
+  - "10.200.0.0 mask 255.255.0.0 nomodify notrap"
 ntp::servers:
-  - '0.amazon.pool.ntp.org iburst'
-  - '1.amazon.pool.ntp.org iburst'
-  - '2.amazon.pool.ntp.org iburst'
-  - '3.amazon.pool.ntp.org iburst'
+  - "0.amazon.pool.ntp.org iburst"
+  - "1.amazon.pool.ntp.org iburst"
+  - "2.amazon.pool.ntp.org iburst"
+  - "3.amazon.pool.ntp.org iburst"
 
 profile::postgresql::username: tadmin
 profile::postgresql::database: tadmin
@@ -86,16 +86,13 @@ profile::postgresql::hostname: "%{::postgres_nodes}"
 profile::postgresql::password: "%{::master_password}"
 
 # Monitoring of installer-based components
-monitoring::node_exporter::version: '0.17.0'
+monitoring::node_exporter::version: "0.17.0"
 monitoring::node_exporter::port: 9100
 
-monitoring::cadvisor::version: '0.32.0'
-monitoring::cadvisor::version_checksum: '62419c0e06edb55a9c02e68fcae3a81abac2a2d98122c36a9124259e0ca8916c'
+monitoring::cadvisor::version: "0.32.0"
+monitoring::cadvisor::version_checksum: "62419c0e06edb55a9c02e68fcae3a81abac2a2d98122c36a9124259e0ca8916c"
 monitoring::cadvisor::port: 9500
 
-monitoring::mongodb_exporter::version: '0.3.1'
-monitoring::mongodb_exporter::port: 9216
-
-monitoring::jmx_exporter::version: '0.12.0'
-monitoring::jmx_exporter::user: 'root'
+monitoring::jmx_exporter::version: "0.12.0"
+monitoring::jmx_exporter::user: "root"
 jmx_exporter_port: 9404

--- a/hieradata/environment/ami.yaml
+++ b/hieradata/environment/ami.yaml
@@ -1,49 +1,47 @@
 ---
-
-tic::services::karaf_service_ensure: 'stopped'
+tic::services::karaf_service_ensure: "stopped"
 tic::services::karaf_service_enable: false
-tic::frontend::tomcat_service_ensure: 'stopped'
+tic::frontend::tomcat_service_ensure: "stopped"
 tic::frontend::tomcat_service_enable: false
 tic::services::init_configuration_service::ensure_init: false
-zookeeper::service_ensure: 'stopped'
+zookeeper::service_ensure: "stopped"
 zookeeper::service_enable: false
-nginx::service_ensure: 'stopped'
-cloudwatchlogs::service_ensure: 'stopped'
+nginx::service_ensure: "stopped"
+cloudwatchlogs::service_ensure: "stopped"
 profile::common::cloudwatchlogs::include: false
 profile::common::ssm::include: false
-profile::postgresql::service_ensure: 'stopped'
+profile::postgresql::service_ensure: "stopped"
 profile::postgresql::service_enable: false
 profile::postgresql::create_databases: false
 
 # Docker
-docker::service_state: 'stopped'
+docker::service_state: "stopped"
 docker::service_enable: false
-profile::docker::registry::ensure: 'absent'
+profile::docker::registry::ensure: "absent"
 profile::docker::registry::running: false
 profile::docker::ecs_agent::running: false
 profile::datadog_docker_agent::running: false
 
-nexus::service_ensure: 'stopped'
+nexus::service_ensure: "stopped"
 nexus::service_enable: false
-syncope::service_ensure: 'stopped'
-activemq::service_ensure: 'stopped'
+syncope::service_ensure: "stopped"
+activemq::service_ensure: "stopped"
 activemq::service_enable: false
-profile::mongodb::service_ensure: 'stopped'
+profile::mongodb::service_ensure: "stopped"
 profile::mongodb::service_enable: false
-profile::mongodb::swap_ensure: 'absent'
-dataprep_dataset::service_ensure: 'stopped'
+profile::mongodb::swap_ensure: "absent"
+dataprep_dataset::service_ensure: "stopped"
 dataprep_dataset::service_enable: false
-profile::elasticsearch::status: 'disabled'
-profile::elasticsearch::security_group: 'not_available'
+profile::elasticsearch::status: "disabled"
+profile::elasticsearch::security_group: "not_available"
 profile::influxdb::service_enable: false
-kafka::broker::service_ensure: 'stopped'
-profile::kafka::kafka_topics_config: ''
+kafka::broker::service_ensure: "stopped"
+profile::kafka::kafka_topics_config: ""
 
-ntp::service_ensure: 'stopped'
+ntp::service_ensure: "stopped"
 ntp::service_enable: false
 
-monitoring::node_exporter::service_ensure: 'stopped'
+monitoring::node_exporter::service_ensure: "stopped"
 monitoring::node_exporter::service_enable: false
-monitoring::cadvisor::service_ensure: 'stopped'
+monitoring::cadvisor::service_ensure: "stopped"
 monitoring::cadvisor::service_enable: false
-monitoring::mongodb_exporter::service_enable: false

--- a/site/profile/manifests/mongodb.pp
+++ b/site/profile/manifests/mongodb.pp
@@ -283,10 +283,4 @@ class profile::mongodb (
 
   contain ::mongodb::server
   contain ::mongodb::client
-
-  $monitor_user = $_users['monitor']
-  class { 'monitoring::mongodb_exporter':
-    mongodb_url => "mongodb://${$monitor_user[username]}:${$monitor_user[password]}@localhost:27017/${$monitor_user[db_address]}",
-    require     => Class['::profile::mongodb::users'],
-  }
 }

--- a/spec/acceptance/shared/mongodb.rb
+++ b/spec/acceptance/shared/mongodb.rb
@@ -240,20 +240,4 @@ shared_examples 'profile::mongodb' do
       it { should be_resolvable.by('hosts') }
     end
   end
-
-  describe 'Mongodb exporter' do
-    describe user('mongodb_exporter') do
-      it { should exist }
-    end
-
-    describe service('mongodb_exporter.service') do
-      it { should be_enabled }
-      it { should be_running }
-    end
-
-    describe command('/usr/bin/curl -v http://127.0.0.1:9216/metrics') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should include 'mongodb_mongod_storage_engine' }
-    end
-  end
 end


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

We are retiring mongodb exporter running locally on instances.

**What is the chosen solution to this problem?**

* remove the usage of the mongodb exporter Puppet class & tests.

**Link to the JIRA issue**

https://jira.talendforge.org/browse/DEVOPS-6356

**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->

**[ ] This Pull Request introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
