### PR TITLE
fix(DEVOPS-9900): Updating datadog version for ami

### DIFF
--- a/hieradata/puppet_role/ecs.yaml
+++ b/hieradata/puppet_role/ecs.yaml
@@ -11,7 +11,7 @@ profile::docker::ecs_agent::running: true
 profile::docker::ecs_agent::cluster_name: "%{::cluster_name}"
 profile::docker::ecs_agent::image: 'amazon/amazon-ecs-agent:v1.34.0'
 
-profile::datadog_docker_agent::image: 'datadog/docker-dd-agent:12.6.5223'
+profile::datadog_docker_agent::image: 'datadog/docker-dd-agent:12.7.5327'
 
 profile::docker::registry::ensure: '%{::registry_ensure}'
 profile::docker::registry::running: true

--- a/site/profile/manifests/docker/datadog_docker_agent.pp
+++ b/site/profile/manifests/docker/datadog_docker_agent.pp
@@ -2,7 +2,7 @@
 
 class profile::docker::datadog_docker_agent (
   $running = true,
-  $image   = 'datadog/docker-dd-agent:12.6.5223',
+  $image   = 'datadog/docker-dd-agent:12.7.5327',
 
 ) {
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
The old dd version is not usable anymore and hence updating it to the new version
**What is the chosen solution to this problem?**
Updating the dd docker version to 12.7.5327 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/DEVOPS-9900

**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->

**[ ] This Pull Request introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
