### PR TITLE
feat(DEVOPS-9905): Change deprecated docker repository, upgrade ECS a…

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -96,3 +96,8 @@ monitoring::cadvisor::port: 9500
 monitoring::jmx_exporter::version: "0.12.0"
 monitoring::jmx_exporter::user: "root"
 jmx_exporter_port: 9404
+
+docker::package_source_location: "https://download.docker.com/linux/centos/7/$basearch/stable"
+docker::package_key_source: "https://download.docker.com/linux/centos/gpg"
+docker::package_name: "docker-ce"
+docker::service_overrides_template: "profile/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb"

--- a/hieradata/puppet_role/ecs.yaml
+++ b/hieradata/puppet_role/ecs.yaml
@@ -3,13 +3,13 @@ common_packages:
   'iptables-services':
     ensure: 'installed'
 
-docker::version: '1.12.3-1.el7.centos'
+docker::version: '19.03.11-3.el7'
 
 profile::docker::host::storage_device: "%{::storage_device}"
 
 profile::docker::ecs_agent::running: true
 profile::docker::ecs_agent::cluster_name: "%{::cluster_name}"
-profile::docker::ecs_agent::image: 'amazon/amazon-ecs-agent:v1.34.0'
+profile::docker::ecs_agent::image: 'amazon/amazon-ecs-agent:v1.39.0'
 
 profile::datadog_docker_agent::image: 'datadog/docker-dd-agent:12.7.5327'
 

--- a/hieradata/puppet_role/test.yaml
+++ b/hieradata/puppet_role/test.yaml
@@ -8,7 +8,7 @@ common_packages:
   'zip':
     ensure: 'present'
 
-docker::version: '1.12.3-1.el7.centos'
+docker::version: '19.03.11-3.el7'
 
 profile::docker::host::storage_device: "%{::storage_device}"
 

--- a/hieradata/puppet_role/test_launcher.yaml
+++ b/hieradata/puppet_role/test_launcher.yaml
@@ -4,7 +4,7 @@ common_packages:
   'zip':
     ensure: 'present'
 
-docker::version: '1.12.3-1.el7.centos'
+docker::version: '19.03.11-3.el7'
 
 profile::docker::registry::running: true
 profile::docker::registry::image: 'registry:2'

--- a/site/profile/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/site/profile/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -1,0 +1,10 @@
+[Service]
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+EnvironmentFile=-/etc/sysconfig/docker-network
+ExecStart=
+ExecStart=/bin/dockerd $OPTIONS \
+      $DOCKER_STORAGE_OPTIONS \
+      $DOCKER_NETWORK_OPTIONS \
+      $BLOCK_REGISTRY \
+      $INSECURE_REGISTRY

--- a/spec/acceptance/shared/docker_host.rb
+++ b/spec/acceptance/shared/docker_host.rb
@@ -2,7 +2,15 @@ shared_examples 'profile::docker_host' do
 
   it_behaves_like 'profile::defined', 'docker_host'
 
-  describe package('docker-engine') do
+  describe package('docker-ce') do
+    it { is_expected.to be_installed }
+  end
+
+  describe package('docker-ce-cli') do
+    it { is_expected.to be_installed }
+  end
+
+  describe package('containerd.io') do
     it { is_expected.to be_installed }
   end
 
@@ -31,19 +39,19 @@ shared_examples 'profile::docker_host' do
   #- Push to your registry
   #  - docker push localhost:5000/test/hello-world:latest
   # Your registry is now ready for this acceptance test
-  describe command('/usr/bin/docker pull hello-world') do
+  describe command('/bin/docker pull hello-world') do
     its(:exit_status) { should eq 0 }
   end
 
-  describe command('/usr/bin/docker tag hello-world localhost:5000/test/hello-world:latest') do
+  describe command('/bin/docker tag hello-world localhost:5000/test/hello-world:latest') do
     its(:exit_status) { should eq 0 }
   end
 
-  describe command('/usr/bin/docker push localhost:5000/test/hello-world:latest') do
+  describe command('/bin/docker push localhost:5000/test/hello-world:latest') do
     its(:exit_status) { should eq 0 }
   end
 
-  describe command('/usr/bin/docker pull localhost:5000/test/hello-world:latest') do
+  describe command('/bin/docker pull localhost:5000/test/hello-world:latest') do
     its(:exit_status) { should eq 0 }
   end
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Docker repository used by default by our docker module was deprecated and stopped

**What is the chosen solution to this problem?**
Overide the parameters to use the new repo from docker, change the docker version, upgrade the ECS agent, adapt the configuration.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/DEVOPS-9905

**Please check if the Pull Request fulfills these requirements**
- [ x ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Related design / discussions / pages (not in JIRA), https://talend.slack.com/archives/C015FB6BMS4/p1591180169001600
