### PR TITLE
chore(DEVOPS-11506): Add a real healthcheck for Nexus

### DIFF
--- a/site/profile/manifests/nexus/nginx.pp
+++ b/site/profile/manifests/nexus/nginx.pp
@@ -83,4 +83,13 @@ class profile::nexus::nginx (
     total => size($_nexus_locations)
   }
 
+  $basic_auth_b64 = base64('encode', "admin:${::nexus::admin_password}", 'strict')
+    nginx::resource::location { 'nexus_healthcheck':
+    vhost                 => $vhost,
+    location              => '= /health',
+    proxy                 => 'http://localhost:8081/nexus/internal/ping',
+    proxy_read_timeout    => '10',
+    proxy_connect_timeout => '10',
+    raw_append            => [ "proxy_set_header Authorization \"Basic ${basic_auth_b64}\";" ]
+  }
 }

--- a/spec/acceptance/shared/nexus.rb
+++ b/spec/acceptance/shared/nexus.rb
@@ -64,6 +64,13 @@ shared_examples 'profile::nexus' do
     end
   end
 
+  describe "testing healthcheck" do
+    subject { command("/usr/bin/curl -v -f -X GET http://localhost:80/health 2>&1") }
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should include 'HTTP/1.1 200 OK' }
+    its(:stdout) { should include 'pong' }
+  end
+
   describe port(80) do
     it { should be_listening }
   end


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
the Nexus healthcheck is giving only nginx status and global nexus access status, not local one.

**What is the chosen solution to this problem?**
Having a real Nexus healthcheck implemented

**Link to the JIRA issue**
https://jira.talendforge.org/browse/DEVOPS-11506

**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->