### PR TITLE
feat(DEVOPS-11587): Remove Shared database provisioning for Ipaas + update ActiveMQ

### DIFF
--- a/hieradata/environment/vagrant.yaml
+++ b/hieradata/environment/vagrant.yaml
@@ -36,6 +36,7 @@ profile::tic_services::nexus_nodes: '[ "10.0.2.12", "10.0.2.23" ]'
 profile::tic_services::nexus_nodes_port: '8081'
 profile::tic_services::cms_nexus_url: 'http://10.0.2.12'
 profile::nexus::nexus_nodes_port: "8081"
+
 profile::postgresql::service_ensure: running
 profile::postgresql::create_databases: true
 profile::postgresql::username: postgres
@@ -47,41 +48,9 @@ postgresql::globals::default_connect_settings:
   PGDATABASE: "postgres"
   PGPASSWORD: "%{::master_password}"
 
-
 activemq::pg_host: "localhost"
 activemq::persistence_pg_host: "localhost"
-# The dict above must be the same than the one inside hieradata/puppet_role/activemq.yaml
-# + activemq
 profile::postgresql::roles:
-  ams:
-    files:
-      - /opt/activemq/lib/tipaas/ams.sql
-      - /opt/activemq/lib/tipaas/amqsec.sql
-  # The following roles shouldn't be placed here, as
-  # well as the ptic-postgresql-schemes package.
-  # The only reason is that the active mq instance A is
-  # used as a single point of postgresql provisioning.
-  scheduler:
-    files:
-      - /var/tmp/sql/scheduler.sql
-  lts:
-    files:
-      - /var/tmp/sql/lts.sql
-  cms:
-    files:
-      - /var/tmp/sql/cms.sql
-  config:
-    files:
-      - /var/tmp/sql/config.sql
-  pe:
-    files:
-      - /var/tmp/sql/pes.sql
-  webhooks:
-    files:
-      - /var/tmp/sql/webhooks.sql
-  notification_subscription:
-    files:
-      - /var/tmp/sql/notification-subscription.sql
   activemq:
     password: "%{::master_password}"
     files: []

--- a/hieradata/puppet_role/activemq.yaml
+++ b/hieradata/puppet_role/activemq.yaml
@@ -4,11 +4,7 @@ java::package: "jre1.8"
 java::version: "1.8.0_181-fcs"
 java::java_home: "/usr/java/jre1.8.0_181-amd64"
 
-common_packages:
-  'ptic-postgresql-schemes':
-    ensure: '2.2-2'
-
-activemq::version: '5.15.11-3'
+activemq::version: '5.15.13-1'
 activemq::tcp_max_frame_size: 104857600  # 100MiB
 activemq::http_max_frame_size: 52428800  # 50MiB
 activemq::jmx_enabled: true
@@ -36,39 +32,6 @@ activemq::jetty_server_max_threads: 3000
 profile::activemq::network_broker_endpoint: '%{::active_mq_network_connect}'
 
 monitoring::jmx_exporter::jmx_exporter_service: 'activemq'
-
-profile::postgresql::roles:
-  ams:
-    files:
-      - /opt/activemq/lib/tipaas/ams.sql
-      - /opt/activemq/lib/tipaas/amqsec.sql
-  # The following roles shouldn't be placed here, as
-  # well as the ptic-postgresql-schemes package.
-  # The only reason is that the active mq instance A is
-  # used as a single point of postgresql provisioning.
-  scheduler:
-    files:
-      - /var/tmp/sql/scheduler.sql
-  lts:
-    files:
-      - /var/tmp/sql/lts.sql
-  cms:
-    files:
-      - /var/tmp/sql/cms.sql
-  config:
-    files:
-      - /var/tmp/sql/config.sql
-  pe:
-    files:
-      - /var/tmp/sql/pes.sql
-  webhooks:
-    files:
-      - /var/tmp/sql/webhooks.sql
-    extension:
-      - pgcrypto
-  notification_subscription:
-    files:
-      - /var/tmp/sql/notification-subscription.sql
 
 cloudwatchlog_files:
   "/talend/tic/%{::main_stack}/%{::puppet_role}/opt/activemq/data/activemq.log":

--- a/spec/acceptance/shared/activemq.rb
+++ b/spec/acceptance/shared/activemq.rb
@@ -24,7 +24,7 @@ shared_examples 'profile::activemq' do
   end
 
   describe package('activemq') do
-    it { should be_installed.with_version('5.15.11-3') }
+    it { should be_installed.with_version('5.15.13-1') }
   end
 
 	describe service('activemq') do
@@ -41,6 +41,10 @@ shared_examples 'profile::activemq' do
 	end
 
   describe package('jre-jce') do
+    it { should_not be_installed }
+  end
+
+  describe package('ptic-postgresql-schemes') do
     it { should_not be_installed }
   end
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Ipaas databases are now modified by 2 paths (amq node A and new K8s provisioning)

**What is the chosen solution to this problem?**
Removing amq provisioning + update AMQ and HukariDB spooler BTW

**Link to the JIRA issue**
https://jira.talendforge.org/browse/DEVOPS-11587

**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request
